### PR TITLE
made ArrayState VkPrimitiveTopology initialization to be VK_PRIMITIVE…

### DIFF
--- a/include/vsg/traversals/ArrayState.h
+++ b/include/vsg/traversals/ArrayState.h
@@ -30,7 +30,7 @@ namespace vsg
             VkFormat format = {};
         };
 
-        VkPrimitiveTopology topology;
+        VkPrimitiveTopology topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
         uint32_t vertex_attribute_location = 0;
         AttributeDetails vertexAttribute;
 


### PR DESCRIPTION
…_TOPOLOGY_TRIANGLE_LIST to match with the default behavior of InputAssemblyState

## Description

I had trouble when trying to get intersections working on my own models. I made the following assumptions initially - please let me know if at a high-level these are valid:

- I could easily take the IntersectionHandler class from vsgintersection example

- The IntersectionHandler could just be applied to a vsg::Group graph and it will just work

The following are some of the notes I went through in order to get the picking work and just understanding how it works:

- Intersector::apply(const VertexIndexDraw& vid) will calculate a BoundingSphere if it can't find one at vid.getValue("bound"). **Does this mean when I load my meshes that I should set this value? Is this the best practice? As noted in the comments as well, this breaks the const contract. Perhaps this should be an error instead if want to use the LineIntersector then you need bounding spheres.**

- vsg::StateGroup interface can trip you up if you're not careful when dealing with add() and addChild(). **I don't think there is a good way to address this from an implementation stand point. Users just have to understand what they are doing here.**

- LineSegmentIntersector::intersectDrawIndexed(uint32_t, uint32_t) has a requirement that the arrayState.topology is VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST. **This just fails silently and took some digging to understand.**

- ArrayState::topology defaults to VK_PRIMITIVE_TOPOLOGY_POINT_LIST. **In relation to the above point, the default implementation of ArrayState makes the you have to understand there is a relationship that VSG needs to put together internally to get the intersections to work properly.**

This PR addresses the last two points. When you create a ```InputAssemblyState``` object - it will automatically default to ```VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST```. However, when the visitor gets applied for the Intersector and you don't have a ```StateCommand``` structure setup somewhere in the graph, it will just silently fail because it defaults to ```VK_PRIMITIVE_TOPOLOGY_POINT_LIST```. I think it's reasonable to make sure that if the ```InputAssemblyState``` is defaulted to triangles - then the ArrayState should default there as well.

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Test Configuration**:
* Hardware:
* Toolchain: MSVC 2019
* SDK: Vulkan 1.2.182.0

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
