### PR TITLE
Added missing include

### DIFF
--- a/include/vsg/utils/CommandLine.h
+++ b/include/vsg/utils/CommandLine.h
@@ -12,6 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
+#include <vsg/core/Export.h>
 #include <vsg/core/type_name.h>
 #include <vsg/io/stream.h>
 


### PR DESCRIPTION
## Description

[This commit](https://github.com/vsg-dev/VulkanSceneGraph/commit/744db6234009835a1ce8079f4ec7e0bd353dc072) added the macro `VSG_DECLSPEC` to the definition of `vsg::CommandLine`, however, the definition of said macro is not included into `utils/Commandline.h` leading the compiler to interpret `VSG_DECLSPEC` as an identifier and to `vsg::CommandLine` not being declared. The issue only occurs when using `vsg::CommandLine` in a different program, not when building vsg itself.
This commit fixes the problem by simply including `core/Export.h` into `utils/Commandline.h`.

There don't appear to be any GitHub issues related to this.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

The effect of this commit can be verified with the following minimal test program:

```cpp
#include <vsg/utils/CommandLine.h>

int main(int argc, char** argv) {
    vsg::CommandLine args (&argc, argv);
}
```

With the unchanged version of vsg the compiler will produce multiple errors starting with 

```
/usr/local/include/vsg/utils/CommandLine.h:40:24: error: variable ‘vsg::VSG_DECLSPEC vsg::CommandLine’ has initializer but incomplete type
   40 |     class VSG_DECLSPEC CommandLine
      |                        ^~~~~~~~~~~
```

Using vsg with the change applied the test program compiles without problems.
The issue can also be avoided by including `core/Export.h` before `utils/CommandLine.h` (or simply including `all.h`), which I assume is the reason it has not caused any problems so far.

**Test Configuration**:
* Build tool: CMake
* Compiler: g++ 10.3.0


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Unticked boxes don't really apply considering the simplicity of the change.