### PR TITLE
inverse key variables for windows

### DIFF
--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -100,12 +100,12 @@ namespace vsgWin32
         return static_cast<vsg::ButtonMask>(mask);
     }
 
-    int getButtonDownEventDetail(UINT buttonMsg)
+    uint32_t getButtonDownEventDetail(UINT buttonMsg)
     {
         return buttonMsg == WM_LBUTTONDOWN ? 1 : (buttonMsg == WM_MBUTTONDOWN ? 2 : buttonMsg == WM_RBUTTONDOWN ? 3 : (buttonMsg == WM_XBUTTONDOWN ? 4 : 0)); // need to determine x1, x2
     }
 
-    int getButtonUpEventDetail(UINT buttonMsg)
+    uint32_t getButtonUpEventDetail(UINT buttonMsg)
     {
         return buttonMsg == WM_LBUTTONUP ? 1 : (buttonMsg == WM_MBUTTONUP ? 2 : buttonMsg == WM_RBUTTONUP ? 3 : (buttonMsg == WM_XBUTTONUP ? 4 : 0));
     }


### PR DESCRIPTION
## Description

Inverse the variables that store the key press events for windows. See Issue #342 for details.

Fixes #342 and vsg-dev/vsgExamples#115

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Ran vsgintrospection example

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
