### PR TITLE
vsgvr - Allow inheritance from Instance and Device

### DIFF
--- a/include/vsg/vk/Device.h
+++ b/include/vsg/vk/Device.h
@@ -35,6 +35,7 @@ namespace vsg
     class VSG_DECLSPEC Device : public Inherit<Object, Device>
     {
     public:
+        Device() = default;
         Device(PhysicalDevice* physicalDevice, const QueueSettings& queueSettings, const Names& layers, const Names& deviceExtensions, const DeviceFeatures* deviceFeatures = nullptr, AllocationCallbacks* allocator = nullptr);
 
         Instance* getInstance() { return _instance.get(); }

--- a/include/vsg/vk/Instance.h
+++ b/include/vsg/vk/Instance.h
@@ -33,6 +33,7 @@ namespace vsg
     class VSG_DECLSPEC Instance : public Inherit<Object, Instance>
     {
     public:
+        Instance() = default;
         Instance(const Names& instanceExtensions, const Names& layers, uint32_t vulkanApiVersion = VK_API_VERSION_1_0, AllocationCallbacks* allocator = nullptr);
 
         /// Vulkan apiVersion used when creating the VkInstaance


### PR DESCRIPTION
For the OpenXR integration I'm currently creating the Vulkan instance through the XR runtime - It's not the only approach, but what I've got for the moment, avoids the issue of selecting the device / parameters that the OpenXR runtime requires.

To do that though I need to be able to create the vsg/vk classes, while bypassing the normal creation logic.
For now I've inherited from a few classes, but needed to add default constructors in vsg to allow it.

Child classes are the following - Ideally they wouldn't exist but the base vsg classes would then need more changes:
* https://github.com/geefr/vsgvr/blob/openxr/vsgvr/src/vsgvr/OpenXRVkInstance.cpp
* https://github.com/geefr/vsgvr/blob/openxr/vsgvr/src/vsgvr/OpenXRVkPhysicalDevice.cpp
* https://github.com/geefr/vsgvr/blob/openxr/vsgvr/src/vsgvr/OpenXRVkDevice.cpp

I'm sure this isn't the best approach, any alternatives would be appreciated. Overall the integration is moving forward, so would be good to resolve this aspect (before thinking about a cleaner 'Viewer' implementation etc).
