### PR TITLE
Fix ray tracing validation errors

### DIFF
--- a/src/vsg/raytracing/AccelerationGeometry.cpp
+++ b/src/vsg/raytracing/AccelerationGeometry.cpp
@@ -55,9 +55,17 @@ void AccelerationGeometry::compile(Context& context)
     auto vertexBufferInfo = vsg::createBufferAndTransferData(context, vertexDataList, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_SHARING_MODE_EXCLUSIVE);
     auto indexBufferInfo = vsg::createBufferAndTransferData(context, indexDataList, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_SHARING_MODE_EXCLUSIVE);
 #else
-    auto vertexBufferInfo = vsg::createHostVisibleBuffer(context.device, vertexDataList, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VK_SHARING_MODE_EXCLUSIVE);
+    auto vertexBufferInfo = vsg::createHostVisibleBuffer(context.device, vertexDataList,
+	VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
+	VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+	VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR,
+	VK_SHARING_MODE_EXCLUSIVE);
     vsg::copyDataListToBuffers(context.device, vertexBufferInfo);
-    auto indexBufferInfo = vsg::createHostVisibleBuffer(context.device, indexDataList, VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VK_SHARING_MODE_EXCLUSIVE);
+    auto indexBufferInfo = vsg::createHostVisibleBuffer(context.device, indexDataList,
+	VK_BUFFER_USAGE_INDEX_BUFFER_BIT | 
+	VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+	VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR,
+	VK_SHARING_MODE_EXCLUSIVE);
     vsg::copyDataListToBuffers(context.device, indexBufferInfo);
 #endif
 

--- a/src/vsg/state/Buffer.cpp
+++ b/src/vsg/state/Buffer.cpp
@@ -158,8 +158,11 @@ ref_ptr<Buffer> vsg::createBufferAndMemory(Device* device, VkDeviceSize size, Vk
     auto buffer = vsg::Buffer::create(size, usage, sharingMode);
     buffer->compile(device);
 
+    VkMemoryAllocateFlagsInfo memFlags = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO };
+    memFlags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+
     auto memRequirements = buffer->getMemoryRequirements(device->deviceID);
-    auto memory = vsg::DeviceMemory::create(device, memRequirements, memoryProperties);
+    auto memory = vsg::DeviceMemory::create(device, memRequirements, memoryProperties, &memFlags);
 
     buffer->bind(memory, 0);
     return buffer;


### PR DESCRIPTION
This fixes the following two validation errors when ray tracing:

`
VUID-vkBindBufferMemory-bufferDeviceAddress-03339(ERROR / SPEC): msgNum: 1151829889 - Validation Error: [ VUID-vkBindBufferMemory-bufferDeviceAddress-03339 ] Object 0: handle = 0xdcc8fd0000000012, type = VK_OBJECT_TYPE_BUFFER; Object 1: handle = 0xd175b40000000013, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x44a78781 | vkBindBufferMemory(): buffer was created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT bit set, memory must have been allocated with the VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT bit set. The Vulkan spec states: If the VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress feature is enabled and buffer was created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT bit set, memory must have been allocated with the VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT bit set (https://vulkan.lunarg.com/doc/view/1.3.283.0/windows/1.3-extensions/vkspec.html#VUID-vkBindBufferMemory-bufferDeviceAddress-03339)
    Objects: 2
        [0] 0xdcc8fd0000000012, type: 9, name: NULL
        [1] 0xd175b40000000013, type: 8, name: NULL
`

`
VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673(ERROR / SPEC): msgNum: -1971459747 - Validation Error: [ VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673 ] Object 0: handle = 0x95a125000000001a, type = VK_OBJECT_TYPE_BUFFER; | MessageID = 0x8a7de95d | vkCmdBuildAccelerationStructuresKHR(): pInfos[0].pGeometries[0].geometry.triangles.indexData has no buffer which created with VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR. The Vulkan spec states: The buffers from which the buffer device addresses for all of the geometry.triangles.vertexData, geometry.triangles.indexData, geometry.triangles.transformData, geometry.aabbs.data, and geometry.instances.data members of all pInfos[i].pGeometries and pInfos[i].ppGeometries are queried must have been created with the VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR usage flag (https://vulkan.lunarg.com/doc/view/1.3.283.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673)
    Objects: 1
        [0] 0x95a125000000001a, type: 9, name: NULL
`

An error still remains about an invalid image layout when running vsgraytracing, however this is a vsgExamples issue.