### PR TITLE
add ubyteArray in intersector

### DIFF
--- a/include/vsg/utils/Intersector.h
+++ b/include/vsg/utils/Intersector.h
@@ -50,6 +50,7 @@ namespace vsg
         void apply(const DrawIndexed& drawIndexed) override;
 
         void apply(const BufferInfo& bufferInfo) override;
+        void apply(const ubyteArray& array) override;
         void apply(const ushortArray& array) override;
         void apply(const uintArray& array) override;
 
@@ -82,6 +83,7 @@ namespace vsg
     protected:
         ArrayStateStack arrayStateStack;
 
+        ref_ptr<const ubyteArray> ubyte_indices;
         ref_ptr<const ushortArray> ushort_indices;
         ref_ptr<const uintArray> uint_indices;
 

--- a/src/vsg/utils/Intersector.cpp
+++ b/src/vsg/utils/Intersector.cpp
@@ -194,14 +194,23 @@ void Intersector::apply(const BufferInfo& bufferInfo)
     if (bufferInfo.data) bufferInfo.data->accept(*this);
 }
 
+void Intersector::apply(const ubyteArray& array)
+{
+    ubyte_indices = &array;
+    ushort_indices = nullptr;
+    uint_indices = nullptr;
+}
+
 void Intersector::apply(const ushortArray& array)
 {
+    ubyte_indices = nullptr;
     ushort_indices = &array;
     uint_indices = nullptr;
 }
 
 void Intersector::apply(const uintArray& array)
 {
+    ubyte_indices = nullptr;
     ushort_indices = nullptr;
     uint_indices = &array;
 }

--- a/src/vsg/utils/PolytopeIntersector.cpp
+++ b/src/vsg/utils/PolytopeIntersector.cpp
@@ -322,7 +322,9 @@ bool PolytopeIntersector::intersectDrawIndexed(uint32_t firstIndex, uint32_t ind
     auto& arrayState = *arrayStateStack.back();
 
     vsg::PrimitiveFunctor<vsg::PolytopePrimitiveIntersection> printPrimtives(*this, arrayState, _polytopeStack.back());
-    if (ushort_indices)
+    if (ubyte_indices)
+        printPrimtives.drawIndexed(arrayState.topology, ubyte_indices, firstIndex, indexCount, firstInstance, instanceCount);
+    else if (ushort_indices)
         printPrimtives.drawIndexed(arrayState.topology, ushort_indices, firstIndex, indexCount, firstInstance, instanceCount);
     else if (uint_indices)
         printPrimtives.drawIndexed(arrayState.topology, uint_indices, firstIndex, indexCount, firstInstance, instanceCount);


### PR DESCRIPTION
I found that intersector and so on polytope don't draw indexed triangles if its indices is ubyte...Is it a mistake or a desired behavior?