### PR TITLE
Add null checks for scenegraph in Intersector::apply(TextTechnique)

### DIFF
--- a/src/vsg/utils/Intersector.cpp
+++ b/src/vsg/utils/Intersector.cpp
@@ -218,9 +218,15 @@ void Intersector::apply(const uintArray& array)
 void Intersector::apply(const TextTechnique& technique)
 {
     if (auto cpuTechnique = technique.cast<CpuLayoutTechnique>())
-        cpuTechnique->scenegraph->accept(*this);
+    {
+        if (cpuTechnique->scenegraph)
+            cpuTechnique->scenegraph->accept(*this);
+    }
     if (auto gpuTechnique = technique.cast<GpuLayoutTechnique>())
-        gpuTechnique->scenegraph->accept(*this);
+    {
+        if (gpuTechnique->scenegraph)
+            gpuTechnique->scenegraph->accept(*this);
+    }
 }
 
 void Intersector::apply(const Draw& draw)


### PR DESCRIPTION
## Description

Previously, Intersector::apply() assumed that CpuLayoutTechnique and GpuLayoutTechnique always had a valid scenegraph, which could lead to segmentation faults. This change adds null checks before calling scenegraph->accept(*this).

The issue occurred when traversing text nodes that contained no glyphs: for example, a text node created with an empty string or when all characters in the string had no corresponding glyphs in the font.

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)


