### PR TITLE
Use option/cmakedefine01 for VSG_SUPPORTS_ShaderCompiler/Windowing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ find_package(Threads REQUIRED)
 set(VSG_MAX_INSTRUMENTATION_LEVEL 1 CACHE STRING "Set the instrumentation level to build into the VSG library, 0 for off, 1 coarse grained, 2 medium, 3 fine grained." )
 
 # Enable/disable shader compilation support that pulls in glslang
-set(VSG_SUPPORTS_ShaderCompiler  1 CACHE STRING "Optional shader compiler support, 0 for off, 1 for enabled." )
+option(VSG_SUPPORTS_ShaderCompiler "Optional shader compiler support" ON)
 if (VSG_SUPPORTS_ShaderCompiler)
 
     # Try looking for glslang 15 first.

--- a/src/vsg/core/Version.h.in
+++ b/src/vsg/core/Version.h.in
@@ -37,7 +37,7 @@ extern "C"
     #define VSG_MAX_INSTRUMENTATION_LEVEL @VSG_MAX_INSTRUMENTATION_LEVEL@
 
     /// vsg::ShaderCompiler support enabled when 1, disabled when 0
-    #define VSG_SUPPORTS_ShaderCompiler @VSG_SUPPORTS_ShaderCompiler@
+    #cmakedefine01 VSG_SUPPORTS_ShaderCompiler
 
     /// vsg::ShaderCompiler optimizer support enabled when 1, disabled when 0
     #cmakedefine01 VSG_SUPPORTS_ShaderOptimizer


### PR DESCRIPTION
## Description

This PR adopts the boolean CMake `option` in combination with `#cmakedefine01` for the  `VSG_SUPPORTS_ShaderCompiler` and `VSG_SUPPORTS_Windowing` options.
This pattern is already in use for `VSG_SUPPORTS_ShaderOptimizer`. It makes it easy to discover the boolean nature of the option, and it makes it hard to pass an unsuitable value. (This PR is triggered by unexpected trouble from using -DVSG_SUPPORTS_Windowing=ON`.)

## Type of change

- Non-breaking change which facilitates configuration.
- A documentation update might not be needed.

## How Has This Been Tested?

- The cmakedefine change for VSG_SUPPORTS_Windowing is added as a patch to the vcpkg port in https://github.com/microsoft/vcpkg/pull/47863. The generated Version.h was checked locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
