### PR TITLE
Consistently return degrees from EllipsoidModel::convertECEFToLatLongAltitude

### DIFF
--- a/src/vsg/app/EllipsoidModel.cpp
+++ b/src/vsg/app/EllipsoidModel.cpp
@@ -94,7 +94,7 @@ dvec3 EllipsoidModel::convertECEFToLatLongAltitude(const dvec3& ecef) const
                 latitude = PI_2;
                 height = -_radiusPolar;
             }
-            return dvec3(latitude, longitude, height);
+            return dvec3(degrees(latitude), degrees(longitude), height);
         }
     }
 


### PR DESCRIPTION
Without this change, `convertECEFToLatLongAltitude` gives results in radians when ECEF $`x`$ component is zero, but in degrees for all other values.
