### PR TITLE
Allow specialisation of vsg::Inherit for sublasses

### DIFF
--- a/include/vsg/core/Inherit.h
+++ b/include/vsg/core/Inherit.h
@@ -23,12 +23,13 @@ namespace vsg
 
     /// Inherit<> uses the Curiously Recurring Template Pattern
     /// to provide the classes versions of create, accept(..), RTTI and sizeofObject()
+    /// There's a layer of indirection to allow subclass-specific specialisation without copying and pasting everything
     template<class ParentClass, class Subclass>
-    class Inherit : public ParentClass
+    class InheritBase : public ParentClass
     {
     public:
         template<typename... Args>
-        Inherit(Args&&... args) :
+        InheritBase(Args&&... args) :
             ParentClass(std::forward<Args>(args)...) {}
 
         template<typename... Args>
@@ -70,6 +71,12 @@ namespace vsg
         void accept(Visitor& visitor) override { visitor.apply(static_cast<Subclass&>(*this)); }
         void accept(ConstVisitor& visitor) const override { visitor.apply(static_cast<const Subclass&>(*this)); }
         void accept(RecordTraversal& visitor) const override { visitor.apply(static_cast<const Subclass&>(*this)); }
+    };
+
+    template<class ParentClass, class Subclass, class Enable = void>
+    class Inherit : public InheritBase<ParentClass, Subclass>
+    {
+        using InheritBase<ParentClass, Subclass>::InheritBase;
     };
 
 } // namespace vsg

--- a/include/vsg/core/Inherit.h
+++ b/include/vsg/core/Inherit.h
@@ -28,9 +28,7 @@ namespace vsg
     class InheritBase : public ParentClass
     {
     public:
-        template<typename... Args>
-        InheritBase(Args&&... args) :
-            ParentClass(std::forward<Args>(args)...) {}
+        using ParentClass::ParentClass;
 
         template<typename... Args>
         static ref_ptr<Subclass> create(Args&&... args)

--- a/include/vsg/state/ArrayState.h
+++ b/include/vsg/state/ArrayState.h
@@ -96,6 +96,23 @@ namespace vsg
     };
     VSG_type_name(vsg::ArrayState);
 
+    template<class ParentClass, class Subclass>
+    class Inherit<ParentClass, Subclass, typename std::enable_if_t<std::is_base_of_v<ArrayState, ParentClass>>> : public InheritBase<ParentClass, Subclass>
+    {
+    public:
+        using InheritBase<ParentClass, Subclass>::InheritBase;
+
+        ref_ptr<ArrayState> cloneArrayState() override
+        {
+            return Subclass::create(static_cast<Subclass&>(*this));
+        }
+
+        ref_ptr<ArrayState> cloneArrayState(ref_ptr<ArrayState> arrayState) override
+        {
+            return Subclass::create(static_cast<Subclass&>(*arrayState));
+        }
+    };
+
     /// NullArrayState provides a mechanism for geometry in a subgraph to be ignored by traversals that use ArrayState such as ComputeBounds/Intersector/LineSegmentIntersector
     /// this is useful for subgraphs that have custom shaders that move the final rendered geometry to a different place that would be naively interpreted by a straight forward vec3Array vertex array in local coordinates.
     /// To disable the handling of geometry in a subgraph simply assign a NullArrayState to the StateGroup::prototypeArrayState, i.e.
@@ -105,9 +122,6 @@ namespace vsg
     public:
         NullArrayState();
         explicit NullArrayState(const ArrayState& as);
-
-        ref_ptr<ArrayState> cloneArrayState() override;
-        ref_ptr<ArrayState> cloneArrayState(ref_ptr<ArrayState> arrayState) override;
 
         using ArrayState::apply;
 
@@ -123,9 +137,6 @@ namespace vsg
         TranslationArrayState();
         TranslationArrayState(const TranslationArrayState& rhs);
         explicit TranslationArrayState(const ArrayState& rhs);
-
-        ref_ptr<ArrayState> cloneArrayState() override;
-        ref_ptr<ArrayState> cloneArrayState(ref_ptr<ArrayState> arrayState) override;
 
         uint32_t translation_attribute_location = 7;
         AttributeDetails translationAttribute;
@@ -144,9 +155,6 @@ namespace vsg
         TranslationRotationScaleArrayState();
         TranslationRotationScaleArrayState(const TranslationRotationScaleArrayState& rhs);
         explicit TranslationRotationScaleArrayState(const ArrayState& rhs);
-
-        ref_ptr<ArrayState> cloneArrayState() override;
-        ref_ptr<ArrayState> cloneArrayState(ref_ptr<ArrayState> arrayState) override;
 
         uint32_t translation_attribute_location = 7;
         uint32_t rotation_attribute_location = 8;
@@ -169,9 +177,6 @@ namespace vsg
         DisplacementMapArrayState();
         DisplacementMapArrayState(const DisplacementMapArrayState& rhs);
         explicit DisplacementMapArrayState(const ArrayState& rhs);
-
-        ref_ptr<ArrayState> cloneArrayState() override;
-        ref_ptr<ArrayState> cloneArrayState(ref_ptr<ArrayState> arrayState) override;
 
         // binding of displacement map
         uint32_t normal_attribute_location = 1;
@@ -207,9 +212,6 @@ namespace vsg
         uint32_t translation_attribute_location = 7;
         AttributeDetails translationAttribute;
 
-        ref_ptr<ArrayState> cloneArrayState() override;
-        ref_ptr<ArrayState> cloneArrayState(ref_ptr<ArrayState> arrayState) override;
-
         void apply(const VertexInputState& vas) override;
         ref_ptr<const vec3Array> vertexArray(uint32_t instanceIndex) override;
     };
@@ -222,9 +224,6 @@ namespace vsg
         BillboardArrayState();
         BillboardArrayState(const BillboardArrayState& rhs);
         explicit BillboardArrayState(const ArrayState& rhs);
-
-        ref_ptr<ArrayState> cloneArrayState() override;
-        ref_ptr<ArrayState> cloneArrayState(ref_ptr<ArrayState> arrayState) override;
 
         uint32_t translation_attribute_location = 7;
         AttributeDetails translationAttribute;

--- a/include/vsg/state/ArrayState.h
+++ b/include/vsg/state/ArrayState.h
@@ -102,6 +102,10 @@ namespace vsg
     public:
         using InheritBase<ParentClass, Subclass>::InheritBase;
 
+        explicit Inherit(const ArrayState& rhs, const CopyOp& copyop = {}) :
+            InheritBase<ParentClass, Subclass>(rhs, copyop)
+        {}
+
         ref_ptr<ArrayState> cloneArrayState() override
         {
             return Subclass::create(static_cast<Subclass&>(*this));
@@ -176,7 +180,7 @@ namespace vsg
     public:
         DisplacementMapArrayState();
         DisplacementMapArrayState(const DisplacementMapArrayState& rhs);
-        explicit DisplacementMapArrayState(const ArrayState& rhs);
+        explicit DisplacementMapArrayState(const ArrayState& rhs, const CopyOp& copyop = {});
 
         // binding of displacement map
         uint32_t normal_attribute_location = 1;

--- a/src/vsg/state/ArrayState.cpp
+++ b/src/vsg/state/ArrayState.cpp
@@ -219,17 +219,6 @@ NullArrayState::NullArrayState(const ArrayState& as) :
     vertices = {};
 }
 
-ref_ptr<ArrayState> NullArrayState::cloneArrayState()
-{
-    return NullArrayState::create(*this);
-}
-
-// clone the specified ArrayState
-ref_ptr<ArrayState> NullArrayState::cloneArrayState(ref_ptr<ArrayState> arrayState)
-{
-    return NullArrayState::create(*arrayState);
-}
-
 void NullArrayState::apply(const vsg::vec3Array&)
 {
     vertices = {};
@@ -258,16 +247,6 @@ TranslationArrayState::TranslationArrayState(const TranslationArrayState& rhs) :
 TranslationArrayState::TranslationArrayState(const ArrayState& rhs) :
     Inherit(rhs)
 {
-}
-
-ref_ptr<ArrayState> TranslationArrayState::cloneArrayState()
-{
-    return TranslationArrayState::create(*this);
-}
-
-ref_ptr<ArrayState> TranslationArrayState::cloneArrayState(ref_ptr<ArrayState> arrayState)
-{
-    return TranslationArrayState::create(*arrayState);
 }
 
 void TranslationArrayState::apply(const VertexInputState& vas)
@@ -313,16 +292,6 @@ TranslationRotationScaleArrayState::TranslationRotationScaleArrayState(const Tra
 TranslationRotationScaleArrayState::TranslationRotationScaleArrayState(const ArrayState& rhs) :
     Inherit(rhs)
 {
-}
-
-ref_ptr<ArrayState> TranslationRotationScaleArrayState::cloneArrayState()
-{
-    return TranslationRotationScaleArrayState::create(*this);
-}
-
-ref_ptr<ArrayState> TranslationRotationScaleArrayState::cloneArrayState(ref_ptr<ArrayState> arrayState)
-{
-    return TranslationRotationScaleArrayState::create(*arrayState);
 }
 
 void TranslationRotationScaleArrayState::apply(const VertexInputState& vas)
@@ -376,16 +345,6 @@ DisplacementMapArrayState::DisplacementMapArrayState(const DisplacementMapArrayS
 DisplacementMapArrayState::DisplacementMapArrayState(const ArrayState& rhs) :
     Inherit(rhs)
 {
-}
-
-ref_ptr<ArrayState> DisplacementMapArrayState::cloneArrayState()
-{
-    return DisplacementMapArrayState::create(*this);
-}
-
-ref_ptr<ArrayState> DisplacementMapArrayState::cloneArrayState(ref_ptr<ArrayState> arrayState)
-{
-    return DisplacementMapArrayState::create(*arrayState);
 }
 
 void DisplacementMapArrayState::apply(const DescriptorImage& di)
@@ -485,16 +444,6 @@ TranslationAndDisplacementMapArrayState::TranslationAndDisplacementMapArrayState
 {
 }
 
-ref_ptr<ArrayState> TranslationAndDisplacementMapArrayState::cloneArrayState()
-{
-    return TranslationAndDisplacementMapArrayState::create(*this);
-}
-
-ref_ptr<ArrayState> TranslationAndDisplacementMapArrayState::cloneArrayState(ref_ptr<ArrayState> arrayState)
-{
-    return TranslationAndDisplacementMapArrayState::create(*arrayState);
-}
-
 void TranslationAndDisplacementMapArrayState::apply(const VertexInputState& vas)
 {
     getAttributeDetails(vas, vertex_attribute_location, vertexAttribute);
@@ -560,16 +509,6 @@ BillboardArrayState::BillboardArrayState(const BillboardArrayState& rhs) :
 BillboardArrayState::BillboardArrayState(const ArrayState& rhs) :
     Inherit(rhs)
 {
-}
-
-ref_ptr<ArrayState> BillboardArrayState::cloneArrayState()
-{
-    return BillboardArrayState::create(*this);
-}
-
-ref_ptr<ArrayState> BillboardArrayState::cloneArrayState(ref_ptr<ArrayState> arrayState)
-{
-    return BillboardArrayState::create(*arrayState);
 }
 
 void BillboardArrayState::apply(const VertexInputState& vas)

--- a/src/vsg/state/ArrayState.cpp
+++ b/src/vsg/state/ArrayState.cpp
@@ -342,8 +342,8 @@ DisplacementMapArrayState::DisplacementMapArrayState(const DisplacementMapArrayS
 {
 }
 
-DisplacementMapArrayState::DisplacementMapArrayState(const ArrayState& rhs) :
-    Inherit(rhs)
+DisplacementMapArrayState::DisplacementMapArrayState(const ArrayState& rhs, const CopyOp& copyop ) :
+    Inherit(rhs, copyop)
 {
 }
 

--- a/src/vsg/text/CpuLayoutTechnique.cpp
+++ b/src/vsg/text/CpuLayoutTechnique.cpp
@@ -47,10 +47,7 @@ public:
     {
     }
 
-    ref_ptr<ArrayState> cloneArrayState() override
-    {
-        return CpuLayoutTechniqueArrayState::create(*this);
-    }
+    using Inherit::cloneArrayState;
 
     ref_ptr<ArrayState> cloneArrayState(ref_ptr<ArrayState> arrayState) override
     {

--- a/src/vsg/text/GpuLayoutTechnique.cpp
+++ b/src/vsg/text/GpuLayoutTechnique.cpp
@@ -51,10 +51,7 @@ public:
     {
     }
 
-    ref_ptr<ArrayState> cloneArrayState() override
-    {
-        return GpuLayoutTechniqueArrayState::create(*this);
-    }
+    using Inherit::cloneArrayState;
 
     ref_ptr<ArrayState> cloneArrayState(ref_ptr<ArrayState> arrayState) override
     {


### PR DESCRIPTION
This allows default implementations of members to be provided, prevents copying and pasting of lots of trivial functions, and makes it possible to generate a compiler error if a subclass fails to provide a particular member without making it a pure virtual function.

This is a pretty close equivalent to how in the OSG, there was a `META_Object` macro that did roughly what the VSG's Inherit template does, but also there were specialised macros like `META_Node` and `META_StateAttribute` to do extra things for particular kinds of object.

I've only used this for `vsg::ArrayState` so far as that was the place where the problem came up in my work (I needed to add extra `cloneArrayState` overloads and ensure subclasses overrode them). I think it's a fairly safe bet that there are other places where using this would be helpful, as I know I've been annoyed by the lack of such a feature in the past, although I can't remember when or why.

This isn't the prettiest code in the world, and has a bonus extra annoying feature that it makes the Visual Studio debugger add an extra level of indentation to loads of things, but it's the best that can be done until P3469 https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3469r0.pdf is ratified and becomes part of C++ (it's too late to get into C++26) and finally makes CRTP fully obsolete.