### PR TITLE
Include all changes to bufferPools in the lock protected block

### DIFF
--- a/src/vsg/vk/MemoryBufferPools.cpp
+++ b/src/vsg/vk/MemoryBufferPools.cpp
@@ -94,23 +94,23 @@ ref_ptr<BufferInfo> MemoryBufferPools::reserveBuffer(VkDeviceSize totalSize, VkD
                 }
             }
         }
-    }
 
-    VkDeviceSize deviceSize = std::max(totalSize, minimumBufferSize);
+        VkDeviceSize deviceSize = std::max(totalSize, minimumBufferSize);
 
-    bufferInfo->buffer = Buffer::create(deviceSize, bufferUsageFlags, sharingMode);
-    bufferInfo->buffer->compile(device);
+        bufferInfo->buffer = Buffer::create(deviceSize, bufferUsageFlags, sharingMode);
+        bufferInfo->buffer->compile(device);
 
-    MemorySlots::OptionalOffset reservedBufferSlot = bufferInfo->buffer->reserve(totalSize, alignment);
-    bufferInfo->offset = reservedBufferSlot.second;
-    bufferInfo->range = totalSize;
+        MemorySlots::OptionalOffset reservedBufferSlot = bufferInfo->buffer->reserve(totalSize, alignment);
+        bufferInfo->offset = reservedBufferSlot.second;
+        bufferInfo->range = totalSize;
 
-    //debug(name, " : Created new Buffer ", bufferInfo->buffer.get(), " totalSize ", totalSize, " deviceSize = ", deviceSize);
+        //debug(name, " : Created new Buffer ", bufferInfo->buffer.get(), " totalSize ", totalSize, " deviceSize = ", deviceSize);
 
-    if (!bufferInfo->buffer->full())
-    {
-        //debug(name, "  inserting new Buffer into Context.bufferPools");
-        bufferPools.push_back(bufferInfo->buffer);
+        if (!bufferInfo->buffer->full())
+        {
+            //debug(name, "  inserting new Buffer into Context.bufferPools");
+            bufferPools.push_back(bufferInfo->buffer);
+        }
     }
 
     //debug(name, " : bufferInfo->offset = ", bufferInfo->offset);


### PR DESCRIPTION

Hi Robert,

Using all VSG master libraries pulled today - Kubuntu 25.10

I've been getting an intermittent, but quite often, crash in MemoryBufferPools::reserveBuffer. It happens while looping through the bufferPools as indicated below. In every case, when I examine variables in the debugger the bufferFromPool value is not even included in the bufferPools. The likely cause would be that bufferPools is being modified in another thread.

My application is compiling a large number of subgraphs all in parallel. All the methods in MemoryBufferPools are protected by locks, but the reserveBuffer method only has a small block protected by the lock. There is a line further down method, outside the lock protected block, that modifies bufferPools (indicated by arrows below)

This PR simply extends the lock protected block to include the bufferPools->push_back() command.

I haven't had any more crashes since making this change.

Regards,
Roland


```
ref_ptr<BufferInfo> MemoryBufferPools::reserveBuffer(VkDeviceSize totalSize, VkDeviceSize alignment, VkBufferUsageFlags bufferUsageFlags, VkSharingMode sharingMode, VkMemoryPropertyFlags memoryProperties)
{
    ref_ptr<BufferInfo> bufferInfo = BufferInfo::create();

    {
        std::scoped_lock<std::mutex> lock(_mutex);
        for (auto& bufferFromPool : bufferPools)           **<--------------- this loop -------------------<<<<<<**
        {
            if (bufferFromPool->usage == bufferUsageFlags && bufferFromPool->size >= totalSize)
            {
                MemorySlots::OptionalOffset reservedBufferSlot = bufferFromPool->reserve(totalSize, alignment);
                if (reservedBufferSlot.first)
                {
                    bufferInfo->buffer = bufferFromPool;
                    bufferInfo->offset = reservedBufferSlot.second;
                    bufferInfo->range = totalSize;
                    return bufferInfo;
                }
            }
        }

        VkDeviceSize deviceSize = std::max(totalSize, minimumBufferSize);

        bufferInfo->buffer = Buffer::create(deviceSize, bufferUsageFlags, sharingMode);
        bufferInfo->buffer->compile(device);

        MemorySlots::OptionalOffset reservedBufferSlot = bufferInfo->buffer->reserve(totalSize, alignment);
        bufferInfo->offset = reservedBufferSlot.second;
        bufferInfo->range = totalSize;

        //debug(name, " : Created new Buffer ", bufferInfo->buffer.get(), " totalSize ", totalSize, " deviceSize = ", deviceSize);

        if (!bufferInfo->buffer->full())
        {
            //debug(name, "  inserting new Buffer into Context.bufferPools");
            bufferPools.push_back(bufferInfo->buffer);                      **<------------------ modified outside lock -----------<<<<<**
        }
    }

    //debug(name, " : bufferInfo->offset = ", bufferInfo->offset);

    VkMemoryRequirements memRequirements;
    vkGetBufferMemoryRequirements(*device, bufferInfo->buffer->vk(device->deviceID), &memRequirements);

    auto reservedMemorySlot = reserveMemory(memRequirements, memoryProperties);

    if (!reservedMemorySlot.first)
    {
        //debug(name, " : Completely Failed to space for MemoryBufferPools::reserveBuffer(", totalSize, ", ", alignment, ", ", bufferUsageFlags, ") ");
        return {};
    }

    //debug(name, " : Allocated new buffer, MemoryBufferPools::reserveBuffer(", totalSize, ", ", alignment, ", ", bufferUsageFlags, ") ");
    bufferInfo->buffer->bind(reservedMemorySlot.first, reservedMemorySlot.second);

    return bufferInfo;
}
```
