### PR TITLE
Fixes a minor QueueSetting "priority" misspelling

### DIFF
--- a/include/vsg/app/WindowTraits.h
+++ b/include/vsg/app/WindowTraits.h
@@ -70,7 +70,7 @@ namespace vsg
         VkImageUsageFlags depthImageUsage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
 
         VkQueueFlags queueFlags = VK_QUEUE_GRAPHICS_BIT;
-        std::vector<float> queuePiorities{1.0, 0.0};
+        std::vector<float> queuePriorities{1.0, 0.0};
         VkPipelineStageFlagBits imageAvailableSemaphoreWaitFlag = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 
         // hints to which extension to enable during Instance/Device setup

--- a/include/vsg/vk/Device.h
+++ b/include/vsg/vk/Device.h
@@ -29,7 +29,7 @@ namespace vsg
     struct QueueSetting
     {
         int queueFamilyIndex = -1;
-        std::vector<float> queuePiorities;
+        std::vector<float> queuePriorities;
     };
 
     using QueueSettings = std::vector<QueueSetting>;

--- a/src/vsg/app/Window.cpp
+++ b/src/vsg/app/Window.cpp
@@ -234,7 +234,7 @@ void Window::_initDevice()
     auto [graphicsFamily, presentFamily] = _physicalDevice->getQueueFamily(_traits->queueFlags, _surface);
     if (graphicsFamily < 0 || presentFamily < 0) throw Exception{"Error: vsg::Window::create(...) failed to create Window, no suitable Vulkan Device available.", VK_ERROR_INVALID_EXTERNAL_HANDLE};
 
-    vsg::QueueSettings queueSettings{vsg::QueueSetting{graphicsFamily, _traits->queuePiorities}, vsg::QueueSetting{presentFamily, {1.0}}};
+    vsg::QueueSettings queueSettings{vsg::QueueSetting{graphicsFamily, _traits->queuePriorities}, vsg::QueueSetting{presentFamily, {1.0}}};
     _device = vsg::Device::create(_physicalDevice, queueSettings, validatedNames, deviceExtensions, _traits->deviceFeatures, _instance->getAllocationCallbacks());
 
     _initFormats();

--- a/src/vsg/app/WindowTraits.cpp
+++ b/src/vsg/app/WindowTraits.cpp
@@ -85,7 +85,7 @@ WindowTraits::WindowTraits(const WindowTraits& traits, const CopyOp& copyop) :
     depthFormat(traits.depthFormat),
     depthImageUsage(traits.depthImageUsage),
     queueFlags(traits.queueFlags),
-    queuePiorities(traits.queuePiorities),
+    queuePriorities(traits.queuePriorities),
     imageAvailableSemaphoreWaitFlag(traits.imageAvailableSemaphoreWaitFlag),
     debugLayer(traits.debugLayer),
     synchronizationLayer(traits.synchronizationLayer),

--- a/src/vsg/vk/Device.cpp
+++ b/src/vsg/vk/Device.cpp
@@ -87,10 +87,10 @@ Device::Device(PhysicalDevice* physicalDevice, const QueueSettings& queueSetting
         queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
         queueCreateInfo.queueFamilyIndex = static_cast<uint32_t>(queueSetting.queueFamilyIndex);
 
-        if (!queueSetting.queuePiorities.empty())
+        if (!queueSetting.queuePriorities.empty())
         {
-            queueCreateInfo.queueCount = static_cast<uint32_t>(queueSetting.queuePiorities.size());
-            queueCreateInfo.pQueuePriorities = queueSetting.queuePiorities.data();
+            queueCreateInfo.queueCount = static_cast<uint32_t>(queueSetting.queuePriorities.size());
+            queueCreateInfo.pQueuePriorities = queueSetting.queuePriorities.data();
 
             uint32_t supportedQueueCount = queueFamilyProperties[queueSetting.queueFamilyIndex].queueCount;
             if (queueCreateInfo.queueCount > supportedQueueCount)


### PR DESCRIPTION
# Description

I noticed a small misspelling of the word "priorities" in `vk/Device.h` and `app/WindowTraits.h`.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
