### PR TITLE
fix: windows compile with ninja/clang

### DIFF
--- a/include/vsg/core/Export.h
+++ b/include/vsg/core/Export.h
@@ -16,7 +16,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #    pragma warning(disable : 4251)
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #    if defined(vsg_EXPORTS)
 #        define VSG_DECLSPEC __declspec(dllexport)
 #    elif defined(VSG_SHARED_LIBRARY)

--- a/src/vsg/io/FileSystem.cpp
+++ b/src/vsg/io/FileSystem.cpp
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <cstdio>
 
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #    include <cstdlib>
 #    include <direct.h>
 #    include <io.h>
@@ -223,7 +223,7 @@ Path vsg::executableFilePath()
 {
     Path path;
 
-#if defined(WIN32)
+#if defined(_WIN32)
     TCHAR buf[PATH_MAX + 1];
     DWORD result = GetModuleFileName(NULL, buf, static_cast<DWORD>(std::size(buf) - 1));
     if (result && result < std::size(buf))


### PR DESCRIPTION
# Pull Request Template

## Description

Building and compiling on Windows with Ninja + Clang doesn't work, so I fixed it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* `cmake -B build . -G "Ninja Multi-Config"`
* `cmake --build build -C Release`

**Test Configuration**:

* Windows 10
* `cmake` version `3.31.6`
* `ninja` version `1.21.1`
* `clang` version `21.1.7`
* Visual Studio 2022 installed for msvcrt
