### PR TITLE
Fixes a misspelling in validateInstancelayerNames

### DIFF
--- a/include/vsg/vk/Instance.h
+++ b/include/vsg/vk/Instance.h
@@ -39,7 +39,7 @@ namespace vsg
     extern VSG_DECLSPEC InstanceLayerProperties enumerateInstanceLayerProperties();
 
     /// return names of layers that are supported from the desired list.
-    extern VSG_DECLSPEC Names validateInstancelayerNames(const Names& names);
+    extern VSG_DECLSPEC Names validateInstanceLayerNames(const Names& names);
 
     /// Instance encapsulates the VkInstance.
     class VSG_DECLSPEC Instance : public Inherit<Object, Instance>

--- a/src/vsg/app/WindowTraits.cpp
+++ b/src/vsg/app/WindowTraits.cpp
@@ -159,5 +159,5 @@ void WindowTraits::validate()
     if (debugLayer) requestedLayers.push_back("VK_LAYER_KHRONOS_validation");
     if (synchronizationLayer) requestedLayers.push_back("VK_LAYER_KHRONOS_synchronization2");
 
-    requestedLayers = vsg::validateInstancelayerNames(requestedLayers);
+    requestedLayers = vsg::validateInstanceLayerNames(requestedLayers);
 }

--- a/src/vsg/vk/Instance.cpp
+++ b/src/vsg/vk/Instance.cpp
@@ -59,7 +59,7 @@ InstanceLayerProperties vsg::enumerateInstanceLayerProperties()
     return availableLayers;
 }
 
-Names vsg::validateInstancelayerNames(const Names& names)
+Names vsg::validateInstanceLayerNames(const Names& names)
 {
     if (names.empty()) return names;
 


### PR DESCRIPTION
# Pull Request Template

## Description

I think this is just another minor misspelling propagated by autocomplete. I'm assuming `validateInstanceLayerNames` was the intended camel-case to be consistent with everything else?

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)