### PR TITLE
Share images and descriptors in GraphicsPipelineConfigurator

### DIFF
--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -675,6 +675,20 @@ bool GraphicsPipelineConfigurator::copyTo(StateCommands& stateCommands, ref_ptr<
                 {
                     if (sharedObjects)
                     {
+                        for (auto& descriptor : ds->descriptors)
+                        {
+                            if (auto descriptor_image = descriptor.cast<vsg::DescriptorImage>())
+                            {
+                                for (auto& image_info : descriptor_image->imageInfoList)
+                                {
+                                    if (image_info->imageView && image_info->imageView->image)
+                                    {
+                                        sharedObjects->share(image_info->imageView->image);
+                                    }
+                                }
+                            }
+                            sharedObjects->share(descriptor);
+                        }
                         sharedObjects->share(ds->setLayout);
                         sharedObjects->share(ds);
                         sharedObjects->share(bindDescriptorSet);


### PR DESCRIPTION
See https://github.com/vsg-dev/VulkanSceneGraph/issues/1629

If I understand the answers right, GraphicsPipelineConfigurator should share images and descriptors.
It works, at least model CompareAmbientOcclusion now has one copy of each texture on GPU.
<img width="1651" height="1475" alt="3" src="https://github.com/user-attachments/assets/96b49d10-eccf-440e-8e83-1ae2e3289bc2" />

