### PR TITLE
Fix vkCmdCopyBuffer SYNC-HAZARD-WRITE-AFTER-WRITE error

### DIFF
--- a/include/vsg/app/TransferTask.h
+++ b/include/vsg/app/TransferTask.h
@@ -17,6 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/vk/CommandBuffer.h>
 #include <vsg/vk/ResourceRequirements.h>
 #include <vsg/vk/Semaphore.h>
+#include <vsg/vk/Fence.h>
 
 namespace vsg
 {
@@ -97,6 +98,8 @@ namespace vsg
             VkDeviceSize dataTotalSize = 0;
             VkDeviceSize imageTotalSize = 0;
 
+            ref_ptr<Fence> transferCompleteFence;
+            bool waitOnTransferFence = false;
             ref_ptr<Semaphore> transferCompleteSemaphore;
             ref_ptr<Semaphore> transferConsumerCompletedSemaphore;
 


### PR DESCRIPTION
These errors appear when enabling "Synchronization" Layer Configuration in Vulkan Configurator and running vsgtext:

`Validation Error: [ SYNC-HAZARD-WRITE-AFTER-WRITE ] | MessageID = 0x5c0ec5d6 vkQueueSubmit(): WRITE_AFTER_WRITE hazard detected. vkCmdCopyBuffer...`

Fix:
Added a per‑TransferTask fence to serialize transfer submissions so back‑to‑back vkCmdCopyBuffer writes can't overlap on the same queue.

OS Windows 11
GPU NVIDIA RTX 2000 Ada Generation Laptop GPU
Driver date 10/12/2025
Vulkan 1.4.328.1