### PR TITLE
fix vsgMacros.cmake

### DIFF
--- a/cmake/vsgMacros.cmake
+++ b/cmake/vsgMacros.cmake
@@ -141,6 +141,11 @@ macro(vsg_add_cmake_support_files)
         DESTINATION
             ${CMAKE_INSTALL_LIBDIR}/cmake/${ARGS_PREFIX}
     )
+    # Buildtree-Export
+    export( EXPORT ${ARGS_PREFIX}Targets
+        FILE ${ARGS_PREFIX}Targets.cmake
+        NAMESPACE ${ARGS_PREFIX}::
+    )
 endmacro()
 
 #


### PR DESCRIPTION
# Pull Request: fix vsg cmake macro "vsg_add_cmake_support_files"

## Description

The macro vsg_add_cmake_support_files is missing an `export( EXPORT )` CMake statement.
- results:
  - in-tree builds not working properly
  - FetchContent does not work with vsg
- fix: simply add corresponding CMake command.

Fixes # no issue created, simply fixed it.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Create a repo, use CMake FetchContent to get current vsg into the build.  Even if all works out well, linking the executable / library to vsg::vsg FAILS.

Create a repo with submodule(s) vsg (and maybe vsgImGui), try to link own executable to vsg::vsg after including vsg via add_subdirectory() → FAILS.

In In-Tree case: this works directly

    add_subdirectory( vsg )
    export( EXPORT vsgTargets NAMESPACE vsg:: )

But it is not a "pro" solution, as this line of code belongs into that macro!

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] I have committed tests that show my fix is working
