### PR TITLE
Fix typo in CompileResult::add()

### DIFF
--- a/src/vsg/app/CompileManager.cpp
+++ b/src/vsg/app/CompileManager.cpp
@@ -50,7 +50,7 @@ void CompileResult::add(const CompileResult& cr)
         binDetails.bins.insert(src_binDetails.bins.begin(), src_binDetails.bins.end());
     }
 
-    dynamicData.add(dynamicData);
+    dynamicData.add(cr.dynamicData);
 }
 
 bool CompileResult::requiresViewerUpdate() const


### PR DESCRIPTION
We have rare crashes of viewer after switching to other location in scene while it was loading multiple of models with PageLODs. It was hard to investegate, once we found that before crash some models are loaded with wrong or corrupted textures. Then we check the source code of the compilation and adding PagedLODs to the scene, and found this typo in handling of dynamic buffers and images at CompileResult. After building with fix we have no more crashes.