### PR TITLE
Fix 'using namespace tracy' at global scope in a header file

### DIFF
--- a/include/vsg/utils/TracyInstrumentation.h
+++ b/include/vsg/utils/TracyInstrumentation.h
@@ -17,10 +17,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/utils/Instrumentation.h>
 
-using namespace tracy;
-
 namespace vsg
 {
+
+    using namespace tracy;
 
     class TracySettings : public Inherit<Object, TracySettings>
     {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

```
#include <vsg/all.h>
#ifdef TRACY_ENABLE
#    include <vsg/utils/TracyInstrumentation.h>
#endif

struct Color{};

Color color;
```

`error C2872: Color: ambiguous symbol can be "Color" or "tracy::Color"`

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
