### PR TITLE
Reset PagedLODs requestStatus after prune the queue

### DIFF
--- a/src/vsg/io/DatabasePager.cpp
+++ b/src/vsg/io/DatabasePager.cpp
@@ -461,6 +461,8 @@ uint32_t DatabaseQueue::prune(uint64_t frameCount)
         {
             // info("pruning ", *itr, ", lastUsed = ", (*itr)->frameHighResLastUsed.load(), " vs ", frameCount, " after ", (*itr)->loadAttempts.load(), " loadAttempts");
             ++numRemoved;
+            (*itr)->requestCount.exchange(0);
+            (*itr)->requestStatus.exchange(PagedLOD::NoRequest);
             itr = _queue.erase(itr);
         }
         else


### PR DESCRIPTION
While testing, I found that some of PagedLOD may become broken forever. When we move to a new location at scene, multiple PagedLODs are added to queue. If we leave this location after short time before all models loading, the rest of them will be deleted from queue by DatabaseQueue::prune(), but they still have status ReadRequest and will be ignored by RecordTraversal next time. I add resetting of status and it works correct now.