### PR TITLE
New ref_ptr

### DIFF
--- a/include/vsg/core/Auxiliary.h
+++ b/include/vsg/core/Auxiliary.h
@@ -32,10 +32,10 @@ namespace vsg
 
         virtual std::size_t getSizeOf() const { return sizeof(Auxiliary); }
 
-        void ref() const;
-        void unref() const;
-        void unref_nodelete() const;
-        inline unsigned int referenceCount() const { return _referenceCount.load(); }
+        //void ref() const;
+        //void unref() const;
+        //void unref_nodelete() const;
+        inline unsigned int referenceCount() const { return _referenceCount->useCount(); }
 
         virtual int compare(const Auxiliary& rhs) const;
 
@@ -97,10 +97,18 @@ namespace vsg
 
         void resetConnectedObject();
 
+        void callDeleteOperator() { delete this; }
+
         friend class Object;
         friend class Allocator;
 
-        mutable std::atomic_uint _referenceCount;
+        template<class T>
+        friend class ref_ptr;
+
+        friend class RefCountBase;
+        friend class detail::RefCountPointer<Auxiliary>;
+
+        RefCountBase* _referenceCount;
 
         mutable std::mutex _mutex;
         Object* _connectedObject;

--- a/include/vsg/core/Inherit.h
+++ b/include/vsg/core/Inherit.h
@@ -34,13 +34,13 @@ namespace vsg
         template<typename... Args>
         static ref_ptr<Subclass> create(Args&&... args)
         {
-            return ref_ptr<Subclass>(new Subclass(std::forward<Args>(args)...));
+            return make_referenced<Subclass>(std::forward<Args>(args)...);
         }
 
         template<typename... Args>
         static ref_ptr<Subclass> create_if(bool flag, Args&&... args)
         {
-            if (flag) return ref_ptr<Subclass>(new Subclass(std::forward<Args>(args)...));
+            if (flag) return make_referenced<Subclass>(std::forward<Args>(args)...);
             return {};
         }
 

--- a/include/vsg/core/Object.h
+++ b/include/vsg/core/Object.h
@@ -64,12 +64,14 @@ namespace vsg
         Object(const Object& object, const CopyOp& copyop = {});
         Object& operator=(const Object&);
 
-        static ref_ptr<Object> create() { return ref_ptr<Object>(new Object); }
+        static ref_ptr<Object> create() {
+            return make_referenced<Object>();
+        }
 
         static ref_ptr<Object> create_if(bool flag)
         {
             if (flag)
-                return ref_ptr<Object>(new Object);
+                return make_referenced<Object>();
             else
                 return {};
         }
@@ -118,14 +120,14 @@ namespace vsg
         virtual void read(Input& input);
         virtual void write(Output& output) const;
 
-        // ref counting methods
-        inline void ref() const noexcept { _referenceCount.fetch_add(1, std::memory_order_relaxed); }
-        inline void unref() const noexcept
-        {
-            if (_referenceCount.fetch_sub(1, std::memory_order_seq_cst) <= 1) _attemptDelete();
-        }
-        inline void unref_nodelete() const noexcept { _referenceCount.fetch_sub(1, std::memory_order_seq_cst); }
-        inline unsigned int referenceCount() const noexcept { return _referenceCount.load(); }
+        // ref counting methods - maybe kill these?
+        //inline void ref() const noexcept { _referenceCount->increment(); }
+        //inline void unref() const noexcept
+        //{
+        //    _referenceCount->decrement();
+        //}
+        //inline void unref_nodelete() const noexcept { _referenceCount.fetch_sub(1, std::memory_order_seq_cst); }
+        inline unsigned int referenceCount() const noexcept { return _referenceCount->useCount(); }
 
         /// meta data access methods
         /// wraps the value with a vsg::Value<T> object and then assigns via setObject(key, vsg::Value<T>)
@@ -182,12 +184,23 @@ namespace vsg
         virtual ~Object();
 
         virtual void _attemptDelete() const;
+        void callDestructor() { this->~Object(); }
+        void callDeleteOperator() const { delete this; }
+        void assignRefCount(RefCountBase* refCount);
+
         void setAuxiliary(Auxiliary* auxiliary);
 
     private:
         friend class Auxiliary;
 
-        mutable std::atomic_uint _referenceCount;
+        template<class T>
+        friend class ref_ptr;
+        template<class T>
+        friend class observer_ptr;
+
+        friend class RefCountBase;
+
+        mutable RefCountBase* _referenceCount;
 
         Auxiliary* _auxiliary;
     };

--- a/include/vsg/core/observer_ptr.h
+++ b/include/vsg/core/observer_ptr.h
@@ -12,7 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/core/Auxiliary.h>
+#include <vsg/core/ref_ptr.h>
 
 namespace vsg
 {
@@ -26,84 +26,120 @@ namespace vsg
         using element_type = T;
 
         observer_ptr() :
-            _ptr(nullptr) {}
+            _ptr(nullptr),
+            _refCount(nullptr)
+        {}
 
         observer_ptr(const observer_ptr& rhs) :
-            _ptr(rhs._ptr),
-            _auxiliary(rhs._auxiliary)
+            _ptr(nullptr),
+            _refCount(rhs._refCount)
         {
+            if (_refCount)
+            {
+                _ptr = rhs._ptr;
+                _refCount->incrementObservers();
+            }
         }
 
         template<class R>
         explicit observer_ptr(R* ptr) :
             _ptr(ptr),
-            _auxiliary(ptr ? ptr->getOrCreateAuxiliary() : nullptr)
+            _refCount(ptr ? ptr->_referenceCount : nullptr)
         {
+            if (_ptr)
+                _refCount->incrementObservers();
         }
 
         template<class R>
         explicit observer_ptr(const observer_ptr<R>& ptr) :
-            _ptr(ptr._ptr),
-            _auxiliary(ptr._auxiliary)
+            _ptr(nullptr),
+            _refCount(ptr._refCount)
         {
+            if (_refCount)
+            {
+                _ptr = ptr._ptr;
+                _refCount->incrementObservers();
+            }
         }
 
         template<class R>
         explicit observer_ptr(const vsg::ref_ptr<R>& ptr) :
             _ptr(ptr.get()),
-            _auxiliary(ptr.valid() ? ptr->getOrCreateAuxiliary() : nullptr)
+            _refCount(ptr.valid() ? ptr->_referenceCount : nullptr)
         {
+            if (_refCount)
+                _refCount->incrementObservers();
         }
 
         ~observer_ptr()
         {
+            if (_refCount)
+                _refCount->decrementObservers();
         }
 
         void reset()
         {
             _ptr = nullptr;
-            _auxiliary.reset();
+            if (_refCount)
+                _refCount->decrementObservers();
+            _refCount = nullptr;
         }
 
         template<class R>
         observer_ptr& operator=(R* ptr)
         {
+            if (_refCount)
+                _refCount->decrementObservers();
             _ptr = ptr;
-            _auxiliary = ptr ? ptr->getOrCreateAuxiliary() : nullptr;
+            _refCount = ptr ? ptr->_referenceCount : nullptr;
+            if (_refCount)
+                _refCount->incrementObservers();
             return *this;
         }
 
         observer_ptr& operator=(const observer_ptr& rhs)
         {
+            if (_refCount)
+                _refCount->decrementObservers();
             _ptr = rhs._ptr;
-            _auxiliary = rhs._auxiliary;
+            _refCount = rhs._refCount;
+            if (_refCount)
+                _refCount->incrementObservers();
             return *this;
         }
 
         template<class R>
         observer_ptr& operator=(const observer_ptr<R>& rhs)
         {
+            if (_refCount)
+                _refCount->decrementObservers();
             _ptr = rhs._ptr;
-            _auxiliary = rhs._auxiliary;
+            _refCount = rhs._refCount;
+            if (_refCount)
+                _refCount->incrementObservers();
             return *this;
         }
 
         template<class R>
         observer_ptr& operator=(const vsg::ref_ptr<R>& rhs)
         {
+            if (_refCount)
+                _refCount->decrementObservers();
             _ptr = rhs.get();
-            _auxiliary = rhs.valid() ? rhs->getOrCreateAuxiliary() : nullptr;
+            _refCount = rhs.valid() ? rhs->_referenceCount : nullptr;
+            if (_refCount)
+                _refCount->incrementObservers();
             return *this;
         }
 
         template<class R>
-        bool operator<(const observer_ptr<R>& rhs) const { return (rhs._ptr < _ptr) || (rhs._ptr == _ptr && rhs._auxiliary < _auxiliary); }
+        bool operator<(const observer_ptr<R>& rhs) const { return (rhs._ptr < _ptr) || (rhs._ptr == _ptr && rhs._refCount < _refCount); }
 
         template<class R>
-        bool operator==(const observer_ptr<R>& rhs) const { return (rhs._auxiliary == _auxiliary); }
+        bool operator==(const observer_ptr<R>& rhs) const { return (rhs._refCount == _refCount); }
 
         template<class R>
-        bool operator!=(const observer_ptr<R>& rhs) const { return (rhs._auxiliary != _auxiliary); }
+        bool operator!=(const observer_ptr<R>& rhs) const { return (rhs._refCount != _refCount); }
 
         template<class R>
         bool operator<(const R* rhs) const
@@ -112,7 +148,7 @@ namespace vsg
                 return true;
             if (_ptr == nullptr)
                 return false;
-            return rhs->getAuxiliary() < _auxiliary;
+            return rhs->_referenceCount < _refCount;
         }
 
         template<class R>
@@ -122,7 +158,7 @@ namespace vsg
                 return false;
             if (rhs == nullptr)
                 return true;
-            return rhs->getAuxiliary() == _auxiliary;
+            return rhs->_referenceCount == _refCount;
         }
 
         template<class R>
@@ -132,7 +168,7 @@ namespace vsg
                 return true;
             if (rhs == nullptr)
                 return false;
-            return rhs->getAuxiliary() != _auxiliary;
+            return rhs->_referenceCount != _refCount;
         }
 
         template<class R>
@@ -142,7 +178,7 @@ namespace vsg
                 return true;
             if (_ptr == nullptr)
                 return false;
-            return rhs->getAuxiliary() < _auxiliary;
+            return rhs->_referenceCount < _refCount;
         }
 
         template<class R>
@@ -152,7 +188,7 @@ namespace vsg
                 return false;
             if (rhs == nullptr)
                 return true;
-            return rhs->getAuxiliary() == _auxiliary;
+            return rhs->_referenceCount == _refCount;
         }
 
         template<class R>
@@ -162,10 +198,10 @@ namespace vsg
                 return true;
             if (rhs == nullptr)
                 return false;
-            return rhs->getAuxiliary() != _auxiliary;
+            return rhs->_referenceCount != _refCount;
         }
 
-        bool valid() const noexcept { return _auxiliary.valid() && _auxiliary->getConnectedObject() != nullptr; }
+        bool valid() const noexcept { return _refCount && _refCount->useCount() > 0; }
 
         explicit operator bool() const noexcept { return valid(); }
 
@@ -176,13 +212,15 @@ namespace vsg
         template<class R>
         operator vsg::ref_ptr<R>() const
         {
-            if (!_auxiliary) return vsg::ref_ptr<R>();
-
-            std::scoped_lock<std::mutex> guard(_auxiliary->getMutex());
-            if (_auxiliary->getConnectedObject() != nullptr)
-                return vsg::ref_ptr<R>(_ptr);
+            if (_refCount && _refCount->incrementIfNonZero())
+            {
+                detail::TemporaryOwner<R> temp{_ptr};
+                return vsg::ref_ptr<R>(temp);
+            }
             else
+            {
                 return {};
+            }
         }
 
     protected:
@@ -190,7 +228,7 @@ namespace vsg
         friend class observer_ptr;
 
         T* _ptr;
-        vsg::ref_ptr<Auxiliary> _auxiliary;
+        RefCountBase* _refCount;
     };
 
 } // namespace vsg

--- a/include/vsg/core/ref_ptr.h
+++ b/include/vsg/core/ref_ptr.h
@@ -12,67 +12,327 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
+#include <atomic>
+#include <memory>
+#include <type_traits>
+
 namespace vsg
 {
-
-    /// smart pointer that works with objects that have intrusive reference counting, such as all vsg::Object
-    /// broadly similar in role to std::shared_ptr<> but half size and faster thanks to lower memory footprint and better cache coherency
+    // smart pointer implementation aiming to get the feature richness of std::shared_ptr with the small pointer size (i.e. the same as a C pointer) of intrusive reference-counting
     template<class T>
+    class ref_ptr;
+
+    template<class T>
+    class observer_ptr;
+
+    class RefCountBase
+    {
+    public:
+        using RefCountType = std::atomic_uint;
+
+        RefCountBase(const RefCountBase&) = delete;
+        RefCountBase& operator=(const RefCountBase&) = delete;
+
+        virtual ~RefCountBase() noexcept = default;
+
+        void increment() noexcept
+        {
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+// GCC bug 107694
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+            _referenceCount.fetch_add(1, std::memory_order_relaxed);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+        }
+
+        bool incrementIfNonZero() noexcept
+        {
+            RefCountType::value_type prevCount = _referenceCount.load();
+            while (prevCount != 0)
+            {
+                if (_referenceCount.compare_exchange_weak(prevCount, prevCount + 1))
+                    return true;
+            }
+            return false;
+        }
+
+        void incrementObservers() noexcept
+        {
+            _observerReferenceCount.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        void decrement() noexcept
+        {
+            if (--_referenceCount == 0)
+            {
+                destroyResource();
+                decrementObservers();
+            }
+        }
+
+        void decrementObservers() noexcept
+        {
+            if (--_observerReferenceCount == 0)
+            {
+                destroyRefCount();
+            }
+        }
+
+        RefCountType::value_type useCount() const noexcept
+        {
+            return _referenceCount;
+        }
+
+    protected:
+        constexpr RefCountBase() noexcept = default;
+
+        template<class T>
+        void callDestructor(T& instance)
+        {
+            instance.callDestructor();
+        }
+
+        template<class T>
+        void callDeleteOperator(T& instance)
+        {
+            instance.callDeleteOperator();
+        }
+
+        template<class T>
+        void assignTo(T& instance)
+        {
+            // assert(instance._referenceCount == nullptr || instance._referenceCount == this);
+            instance._referenceCount = this;
+        }
+
+    private:
+        virtual void destroyResource() noexcept = 0;
+        virtual void destroyRefCount() noexcept = 0;
+
+        RefCountType _referenceCount = 1;
+        RefCountType _observerReferenceCount = 1;
+    };
+
+    // we've got lots of template magic to make this work, but don't want to pollute the main namespace
+    namespace detail
+    {
+        template<class T>
+        class RefCountPointer : public RefCountBase
+        {
+        public:
+            explicit RefCountPointer(T* ptr) :
+                RefCountBase(),
+                _ptr(ptr)
+            {
+                assignTo(*_ptr);
+            }
+
+        private:
+            void destroyResource() noexcept override
+            {
+                callDeleteOperator(*_ptr);
+            }
+
+            void destroyRefCount() noexcept override
+            {
+                delete this;
+            }
+
+            T* _ptr;
+        };
+
+        template<class T, class = void>
+        struct NeedsRefCountEarly : std::false_type
+        {
+        };
+
+        template<class T>
+        struct NeedsRefCountEarly<T, std::void_t<typename T::NeedsRefCountInConstructor>>
+            : T::NeedsRefCountInConstructor
+        {
+        };
+
+        template<class Res, class Deleter>
+        class RefCountResource : public RefCountBase
+        {
+        public:
+            RefCountResource(Res resource, Deleter deleter) :
+                RefCountBase(),
+                _resource(resource),
+                _deleter(deleter)
+            {}
+
+            ~RefCountResource() noexcept override = default;
+
+        private:
+            void destroyResource() noexcept override
+            {
+                _deleter(_resource);
+            }
+
+            void destroyRefCount() noexcept override
+            {
+                delete this;
+            }
+
+            // todo: compressed pair/no_unique_address
+            Res _resource;
+            Deleter _deleter;
+        };
+
+        // RefCountResourceWithAllocator
+
+#ifdef _MSC_VER
+#    pragma warning(push)
+#    pragma warning(disable : 4624) // '%s': destructor was implicitly defined as deleted
+#endif
+        template<class T>
+        class RefCountWithObject : public RefCountBase
+        {
+        public:
+            static void* operator new(std::size_t count)
+            {
+                return T::operator new(count);
+            }
+
+            static void operator delete(void* ptr)
+            {
+                T::operator delete(ptr);
+            }
+
+            template<class... Args>
+            explicit RefCountWithObject(Args&&... args) :
+                RefCountBase()
+            {
+                if constexpr (NeedsRefCountEarly<T>::value)
+                {
+                    ::new ((void*)&storage) T(this, std::forward<Args>(args)...);
+                }
+                else
+                {
+                    ::new ((void*)&storage) T(std::forward<Args>(args)...);
+                }
+                assignTo(storage);
+            }
+
+            ~RefCountWithObject() noexcept override
+            {
+                // can't use default keyword due to the union, but we don't want to do anything here
+            }
+
+            // trick to prevent double-destruction
+            union
+            {
+                std::remove_cv_t<T> storage;
+            };
+
+        private:
+            void destroyResource() noexcept override
+            {
+                callDestructor(storage);
+            }
+
+            void destroyRefCount() noexcept override
+            {
+                delete this;
+            }
+        };
+
+        template<class T, class Alloc>
+        class RefCountWithObjectAndAllocator : public RefCountBase
+        {
+        private:
+            static_assert(std::is_same_v<T, std::remove_cv_t<T>>, "allocate_shared didn't remove_cv_t");
+
+        public:
+            using Rebound = typename std::allocator_traits<Alloc>::template rebind_alloc<RefCountWithObjectAndAllocator>;
+
+            template<class... Args>
+            explicit RefCountWithObjectAndAllocator(const Alloc& alloc, Args&&... args) :
+                RefCountBase(),
+                allocator(alloc)
+            {
+                // roughly equivalent to
+                // alloc.construct(&storage, std::forward<Args>(args)...);
+                // we can't use that, though, as vsg::Object destructor is protected, so std::is_constructible_v is false
+                if constexpr (!std::uses_allocator_v<T, decltype(alloc)>)
+                {
+                    ::new ((void*)&storage) T(std::forward<Args>(args)...);
+                }
+                else
+                {
+                    ::new ((void*)&storage) T(std::forward<Args>(args)..., alloc);
+                }
+                assignTo(storage);
+            }
+
+            ~RefCountWithObjectAndAllocator() noexcept
+            {
+                // can't use default keyword due to the union, but we don't want to do anything here
+            }
+
+            // trick to prevent double-destruction
+            union
+            {
+                T storage;
+            };
+
+            // todo: empty base optimisation/no_unique_address
+            Rebound allocator;
+
+        private:
+            void destroyResource() noexcept override
+            {
+                callDestructor(storage);
+            }
+
+            void destroyRefCount() noexcept override
+            {
+                this->~RefCountWithObjectAndAllocator();
+                std::allocator_traits<Rebound>::deallocate(allocator, this, 1);
+            }
+        };
+#ifdef _MSC_VER
+#    pragma warning(pop)
+#endif
+
+        template<class T>
+        struct TemporaryOwner
+        {
+            T* ptr = nullptr;
+        };
+    } // namespace detail
+
+    template <class T>
     class ref_ptr
     {
     public:
         using element_type = T;
+        using observer_type = observer_ptr<T>;
 
-        ref_ptr() noexcept :
-            _ptr(nullptr) {}
+        constexpr ref_ptr() noexcept = default;
 
-        ref_ptr(const ref_ptr& rhs) noexcept :
-            _ptr(rhs._ptr)
+        constexpr ref_ptr(std::nullptr_t) noexcept {}
+
+        ref_ptr(detail::TemporaryOwner<T>& ptr) noexcept :
+            _ptr(ptr.ptr)
         {
-            if (_ptr) _ptr->ref();
-        }
-
-        /// move constructor
-        template<class R>
-        ref_ptr(ref_ptr<R>&& rhs) noexcept :
-            _ptr(rhs._ptr)
-        {
-            rhs._ptr = nullptr;
-        }
-
-        template<class R>
-        ref_ptr(const ref_ptr<R>& ptr) noexcept :
-            _ptr(ptr._ptr)
-        {
-            if (_ptr) _ptr->ref();
+            ptr.ptr = nullptr;
         }
 
         explicit ref_ptr(T* ptr) noexcept :
             _ptr(ptr)
         {
-            if (_ptr) _ptr->ref();
-        }
-
-        template<class R>
-        explicit ref_ptr(R* ptr) noexcept :
-            _ptr(ptr)
-        {
-            if (_ptr) _ptr->ref();
-        }
-
-        // std::nullptr_t requires extra header
-        ref_ptr(decltype(nullptr)) noexcept :
-            ref_ptr() {}
-
-        ~ref_ptr()
-        {
-            if (_ptr) _ptr->unref();
-        }
-
-        void reset()
-        {
-            if (_ptr) _ptr->unref();
-            _ptr = nullptr;
+            if (_ptr)
+            {
+                if (_ptr->_referenceCount)
+                    _ptr->_referenceCount->increment();
+                else
+                    _ptr->_referenceCount = new detail::RefCountPointer(_ptr);
+            }
         }
 
         ref_ptr& operator=(T* ptr)
@@ -83,120 +343,117 @@ namespace vsg
 
             _ptr = ptr;
 
-            if (_ptr) _ptr->ref();
+            if (_ptr)
+            {
+                if (_ptr->_referenceCount)
+                    _ptr->_referenceCount->increment();
+                else
+                    _ptr->_referenceCount = new detail::RefCountPointer(_ptr);
+            }
 
             // unref the original pointer after ref in case the old pointer object is a parent of the new pointer's object
-            if (temp_ptr) temp_ptr->unref();
+            if (temp_ptr) temp_ptr->_referenceCount->decrement();
 
             return *this;
         }
 
-        ref_ptr& operator=(const ref_ptr& rhs)
+        ref_ptr(const ref_ptr& rhs) noexcept:
+            _ptr(rhs._ptr)
         {
-            if (rhs._ptr == _ptr) return *this;
-
-            T* temp_ptr = _ptr;
-
-            _ptr = rhs._ptr;
-
-            if (_ptr) _ptr->ref();
-
-            // unref the original pointer after ref in case the old pointer object is a parent of the new pointer's object
-            if (temp_ptr) temp_ptr->unref();
-
-            return *this;
+            if (_ptr)
+                _ptr->_referenceCount->increment();
         }
 
-        template<class R>
-        ref_ptr& operator=(const ref_ptr<R>& rhs)
+        ref_ptr& operator=(const ref_ptr& rhs) noexcept
         {
-            if (rhs._ptr == _ptr) return *this;
-
-            T* temp_ptr = _ptr;
-
-            _ptr = rhs._ptr;
-
-            if (_ptr) _ptr->ref();
-
-            // unref the original pointer after ref in case the old pointer object is a parent of the new pointer's object
-            if (temp_ptr) temp_ptr->unref();
-
+            ref_ptr(rhs).swap(*this);
             return *this;
         }
 
-        /// move assignment
         template<class R>
-        ref_ptr& operator=(ref_ptr<R>&& rhs)
+        ref_ptr(const ref_ptr<R>& rhs) noexcept :
+            _ptr(rhs._ptr)
         {
-            if (rhs._ptr == _ptr) return *this;
-
-            if (_ptr) _ptr->unref();
-
-            _ptr = rhs._ptr;
-
-            rhs._ptr = nullptr;
-
-            return *this;
+            if (_ptr)
+                _ptr->_referenceCount->increment();
         }
 
         template<class R>
-        bool operator<(const ref_ptr<R>& rhs) const { return (_ptr < rhs._ptr); }
+        ref_ptr& operator=(const ref_ptr<R>& rhs) noexcept
+        {
+            ref_ptr(rhs).swap(*this);
+            return *this;
+        }
 
-        template<class R>
-        bool operator==(const ref_ptr<R>& rhs) const { return (rhs._ptr == _ptr); }
+        ~ref_ptr() noexcept
+        {
+            if (_ptr)
+                _ptr->_referenceCount->decrement();
+        }
 
-        template<class R>
-        bool operator!=(const ref_ptr<R>& rhs) const { return (rhs._ptr != _ptr); }
+        void reset() noexcept
+        {
+            ref_ptr().swap(*this);
+        }
 
-        template<class R>
-        bool operator<(const R* rhs) const { return (_ptr < rhs); }
+        void swap(ref_ptr& other) noexcept
+        {
+            std::swap(_ptr, other._ptr);
+        }
 
-        template<class R>
-        bool operator==(const R* rhs) const { return (rhs == _ptr); }
+        [[nodiscard]] element_type* get() const noexcept
+        {
+            return _ptr;
+        }
 
-        template<class R>
-        bool operator!=(const R* rhs) const { return (rhs != _ptr); }
+        bool valid() const noexcept
+        {
+            return get() != nullptr;
+        }
 
-        bool valid() const noexcept { return _ptr != nullptr; }
+        explicit operator bool() const noexcept
+        {
+            return valid();
+        }
 
-        explicit operator bool() const noexcept { return valid(); }
+        T& operator*() const noexcept { return *_ptr; }
+
+        T* operator->() const noexcept { return _ptr; }
 
         // potentially dangerous automatic type conversion, could cause dangling pointer if ref_ptr<> assigned to C pointer and ref_ptr<> destruction causes an object delete.
         operator T*() const noexcept { return _ptr; }
 
         void operator[](int) const = delete;
 
-        T& operator*() const noexcept { return *_ptr; }
-
-        T* operator->() const noexcept { return _ptr; }
-
-        T* get() const noexcept { return _ptr; }
-
-        T* release_nodelete() noexcept
-        {
-            T* temp_ptr = _ptr;
-
-            if (_ptr) _ptr->unref_nodelete();
-            _ptr = nullptr;
-
-            return temp_ptr;
-        }
-
-        void swap(ref_ptr& rhs) noexcept
-        {
-            T* temp_ptr = _ptr;
-            _ptr = rhs._ptr;
-            rhs._ptr = temp_ptr;
-        }
-
         template<class R>
         ref_ptr<R> cast() const { return ref_ptr<R>(_ptr ? _ptr->template cast<R>() : nullptr); }
 
-    protected:
+    private:
         template<class R>
         friend class ref_ptr;
 
-        T* _ptr;
+        element_type* _ptr = nullptr;
     };
+
+    // like std::make_shared
+    template<class T, class... Args>
+    [[nodiscard]] ref_ptr<T> make_referenced(Args&&... args)
+    {
+        auto* controlBlock = new detail::RefCountWithObject<T>(std::forward<Args>(args)...);
+        detail::TemporaryOwner<T> temp{std::addressof(controlBlock->storage)};
+        return ref_ptr<T>(temp);
+    }
+
+    // like std::allocate_shared
+    template<class T, class Alloc, class... Args>
+    [[nodiscard]] ref_ptr<T> allocate_referenced(const Alloc& allocator, Args&&... args)
+    {
+        using ControlBlock = detail::RefCountWithObjectAndAllocator<std::remove_cv_t<T>, Alloc>;
+        auto reboundAlloc = typename ControlBlock::Rebound(allocator);
+        ControlBlock* controlBlock = std::allocator_traits<typename ControlBlock::Rebound>::allocate(reboundAlloc, 1);
+        ::new ((void*)controlBlock) ControlBlock(reboundAlloc, std::forward<Args>(args)...);
+        detail::TemporaryOwner<T> temp{std::addressof(controlBlock->storage)};
+        return ref_ptr<T>(temp);
+    }
 
 } // namespace vsg

--- a/include/vsg/core/ref_ptr.h
+++ b/include/vsg/core/ref_ptr.h
@@ -130,6 +130,16 @@ namespace vsg
                 assignTo(*_ptr);
             }
 
+            template<class... Args>
+            explicit RefCountPointer(Args&&... args) :
+                RefCountBase(),
+                _ptr(new T(this, std::forward<Args>(args)...))
+            {
+                assignTo(*_ptr);
+            }
+
+            T* _ptr;
+
         private:
             void destroyResource() noexcept override
             {
@@ -140,8 +150,6 @@ namespace vsg
             {
                 delete this;
             }
-
-            T* _ptr;
         };
 
         template<class T, class = void>
@@ -435,9 +443,28 @@ namespace vsg
         element_type* _ptr = nullptr;
     };
 
-    // like std::make_shared
+    // like std::make_shared, but allocates the ref count separately
     template<class T, class... Args>
     [[nodiscard]] ref_ptr<T> make_referenced(Args&&... args)
+    {
+        if constexpr (detail::NeedsRefCountEarly<T>::value)
+        {
+            auto* controlBlock = new detail::RefCountPointer<T>(std::forward<Args>(args)...);
+            detail::TemporaryOwner<T> temp{controlBlock->_ptr};
+            return ref_ptr<T>(temp);
+        }
+        else
+        {
+            auto* instance = new T(std::forward<Args>(args)...);
+            new detail::RefCountPointer<T>(instance);
+            detail::TemporaryOwner<T> temp{instance};
+            return ref_ptr<T>(temp);
+        }
+    }
+
+    // like std::make_shared
+    template<class T, class... Args>
+    [[nodiscard]] ref_ptr<T> make_referenced_adjacent_ref_count(Args&&... args)
     {
         auto* controlBlock = new detail::RefCountWithObject<T>(std::forward<Args>(args)...);
         detail::TemporaryOwner<T> temp{std::addressof(controlBlock->storage)};
@@ -446,7 +473,7 @@ namespace vsg
 
     // like std::allocate_shared
     template<class T, class Alloc, class... Args>
-    [[nodiscard]] ref_ptr<T> allocate_referenced(const Alloc& allocator, Args&&... args)
+    [[nodiscard]] ref_ptr<T> allocate_referenced_adjacent_ref_count(const Alloc& allocator, Args&&... args)
     {
         using ControlBlock = detail::RefCountWithObjectAndAllocator<std::remove_cv_t<T>, Alloc>;
         auto reboundAlloc = typename ControlBlock::Rebound(allocator);

--- a/include/vsg/platform/ios/iOS_Window.h
+++ b/include/vsg/platform/ios/iOS_Window.h
@@ -46,6 +46,7 @@ namespace vsgiOS
     class iOS_Window : public vsg::Inherit<vsg::Window, iOS_Window>
     {
     public:
+        using NeedsRefCountInConstructor = std::true_type;
 
         iOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits);
         iOS_Window() = delete;

--- a/include/vsg/platform/macos/MacOS_Window.h
+++ b/include/vsg/platform/macos/MacOS_Window.h
@@ -49,8 +49,9 @@ namespace vsgMacOS
     class MacOS_Window : public vsg::Inherit<vsg::Window, MacOS_Window>
     {
     public:
+        using NeedsRefCountInConstructor = std::true_type;
 
-        MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits);
+        MacOS_Window(vsg::RefCountBase* refCount, ::ref_ptr<vsg::WindowTraits> traits);
         MacOS_Window() = delete;
         MacOS_Window(const MacOS_Window&) = delete;
         MacOS_Window operator = (const MacOS_Window&) = delete;

--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -183,7 +183,9 @@ namespace vsgWin32
     class VSG_DECLSPEC Win32_Window : public vsg::Inherit<vsg::Window, Win32_Window>
     {
     public:
-        Win32_Window(vsg::ref_ptr<vsg::WindowTraits> traits);
+        using NeedsRefCountInConstructor = std::true_type;
+
+        Win32_Window(vsg::RefCountBase* refCount, vsg::ref_ptr<vsg::WindowTraits> traits);
         Win32_Window() = delete;
         Win32_Window(const Win32_Window&) = delete;
         Win32_Window operator=(const Win32_Window&) = delete;

--- a/include/vsg/vk/DeviceMemory.h
+++ b/include/vsg/vk/DeviceMemory.h
@@ -28,7 +28,9 @@ namespace vsg
     class VSG_DECLSPEC DeviceMemory : public Inherit<Object, DeviceMemory>
     {
     public:
-        DeviceMemory(Device* device, const VkMemoryRequirements& memRequirements, VkMemoryPropertyFlags properties, void* pNextAllocInfo = nullptr);
+        using NeedsRefCountInConstructor = std::true_type;
+
+        DeviceMemory(RefCountBase* refCount, Device* device, const VkMemoryRequirements& memRequirements, VkMemoryPropertyFlags properties, void* pNextAllocInfo = nullptr);
 
         operator VkDeviceMemory() const { return _deviceMemory; }
         VkDeviceMemory vk() const { return _deviceMemory; }

--- a/include/vsg/vk/Instance.h
+++ b/include/vsg/vk/Instance.h
@@ -48,7 +48,9 @@ namespace vsg
     class VSG_DECLSPEC Instance : public Inherit<Object, Instance>
     {
     public:
-        Instance(Names instanceExtensions, Names layers, uint32_t vulkanApiVersion = VK_API_VERSION_1_0, AllocationCallbacks* allocator = nullptr);
+        using NeedsRefCountInConstructor = std::true_type;
+
+        Instance(RefCountBase* refCount, Names instanceExtensions, Names layers, uint32_t vulkanApiVersion = VK_API_VERSION_1_0, AllocationCallbacks* allocator = nullptr);
 
         /// Vulkan apiVersion used when creating the VkInstance
         const uint32_t apiVersion = VK_API_VERSION_1_0;

--- a/src/vsg/core/Auxiliary.cpp
+++ b/src/vsg/core/Auxiliary.cpp
@@ -19,9 +19,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 using namespace vsg;
 
 Auxiliary::Auxiliary(Object* object) :
-    _referenceCount(0),
+    _referenceCount(nullptr),
     _connectedObject(object)
 {
+    new detail::RefCountPointer(this);
     //vsg::debug("Auxiliary::Auxiliary(Object = ", object, ") ", this);
 }
 
@@ -30,26 +31,26 @@ Auxiliary::~Auxiliary()
     //vsg::debug("Auxiliary::~Auxiliary() ", this);
 }
 
-void Auxiliary::ref() const
-{
-    ++_referenceCount;
-    //debug("Auxiliary::ref() ", this, " ", _referenceCount.load());
-}
-
-void Auxiliary::unref() const
-{
-    //debug("Auxiliary::unref() ", this, " ", _referenceCount.load());
-    if (_referenceCount.fetch_sub(1) <= 1)
-    {
-        delete this;
-    }
-}
-
-void Auxiliary::unref_nodelete() const
-{
-    //debug("Auxiliary::unref_nodelete() ", this, " ", _referenceCount.load());
-    --_referenceCount;
-}
+//void Auxiliary::ref() const
+//{
+//    ++_referenceCount;
+//    //debug("Auxiliary::ref() ", this, " ", _referenceCount.load());
+//}
+//
+//void Auxiliary::unref() const
+//{
+//    //debug("Auxiliary::unref() ", this, " ", _referenceCount.load());
+//    if (_referenceCount.fetch_sub(1) <= 1)
+//    {
+//        delete this;
+//    }
+//}
+//
+//void Auxiliary::unref_nodelete() const
+//{
+//    //debug("Auxiliary::unref_nodelete() ", this, " ", _referenceCount.load());
+//    --_referenceCount;
+//}
 
 bool Auxiliary::signalConnectedObjectToBeDeleted()
 {

--- a/src/vsg/core/Object.cpp
+++ b/src/vsg/core/Object.cpp
@@ -31,14 +31,24 @@ Object::Object() :
 Object::Object(const Object& rhs, const CopyOp& copyop) :
     Object()
 {
+    /* I'm not sure this block can ever do anything productive - if it's called from CopyOp, and itr->second is null,
+       then CopyOp will assign this itself, and if it's not null, then it'll use the existing value instead of constructing
+       something fresh.
+       I think that's the only sane callsite.
+       However, this was added a couple of weeks after the CopyOp stuff that I think makes it seem redundant, so maybe I'm
+       missing something.
+
+       While it's detonative, I'll just comment it out.
+
     // assign this copy constructed object to copyop.duplicate so that it can be lated referenced.
     if (copyop.duplicate)
     {
         if (auto itr = copyop.duplicate->find(&rhs); itr != copyop.duplicate->end())
         {
+            // this will blow up as the refcount hasn't been set yet
             itr->second = this;
         }
-    }
+    } */
 
     if (rhs._auxiliary && rhs._auxiliary->getConnectedObject() == &rhs)
     {
@@ -77,7 +87,8 @@ Object::~Object()
 
     if (_auxiliary)
     {
-        _auxiliary->unref();
+        _auxiliary->resetConnectedObject();
+        _auxiliary->_referenceCount->decrement();
     }
 }
 
@@ -206,19 +217,25 @@ void Object::removeObject(const std::string& key)
     }
 }
 
+void Object::assignRefCount(RefCountBase* refCount)
+{
+    //assert(_referenceCount == nullptr || _referenceCount == refCount);
+    _referenceCount = refCount;
+}
+
 void Object::setAuxiliary(Auxiliary* auxiliary)
 {
     if (_auxiliary)
     {
         _auxiliary->resetConnectedObject();
-        _auxiliary->unref();
+        _auxiliary->_referenceCount->decrement();
     }
 
     _auxiliary = auxiliary;
 
     if (auxiliary)
     {
-        auxiliary->ref();
+        auxiliary->_referenceCount->increment();
     }
 }
 
@@ -228,7 +245,6 @@ Auxiliary* Object::getOrCreateAuxiliary()
     if (!_auxiliary)
     {
         _auxiliary = new Auxiliary(this);
-        _auxiliary->ref();
     }
     return _auxiliary;
 }

--- a/src/vsg/io/Options.cpp
+++ b/src/vsg/io/Options.cpp
@@ -10,6 +10,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
+#include <vsg/core/Auxiliary.h>
 #include <vsg/io/Options.h>
 #include <vsg/io/ReaderWriter.h>
 #include <vsg/state/DescriptorSetLayout.h>

--- a/src/vsg/platform/ios/iOS_Window.mm
+++ b/src/vsg/platform/ios/iOS_Window.mm
@@ -256,9 +256,11 @@ namespace vsgiOS
     };
 }
 
-vsgiOS::iOS_Window::iOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits)
+vsgiOS::iOS_Window::iOS_Window(vsg::RefCountBase* refCount, vsg::ref_ptr<vsg::WindowTraits> traits)
     : Inherit(traits)
 {
+    assignRefCount(refCount);
+
     auto devicePixelScale = _traits->hdpi ?  UIScreen.mainScreen.nativeScale : 1.0f;
     _window = std::any_cast<vsg_iOS_Window*>(traits->nativeWindow);
     _view = (vsg_iOS_View*)( _window.rootViewController.view );

--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -707,9 +707,11 @@ bool KeyboardMap::getKeySymbol(NSEvent* anEvent, vsg::KeySymbol& keySymbol, vsg:
     return true;
 }
 
-MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
+MacOS_Window::MacOS_Window(vsg::RefCountBase* refCount, vsg::ref_ptr<vsg::WindowTraits> traits) :
     Inherit(traits)
 {
+    assignRefCount(refCount);
+
     _keyboard = new KeyboardMap;
 
     NSRect contentRect = NSMakeRect(0, 0, traits->width, traits->height);

--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -328,10 +328,12 @@ KeyboardMap::KeyboardMap()
     // clang-format on
 }
 
-Win32_Window::Win32_Window(vsg::ref_ptr<WindowTraits> traits) :
+Win32_Window::Win32_Window(RefCountBase* refCount, vsg::ref_ptr<WindowTraits> traits) :
     Inherit(traits),
     _window(nullptr)
 {
+    assignRefCount(refCount);
+
     _keyboard = new KeyboardMap;
 
 #ifdef UNICODE

--- a/src/vsg/vk/DeviceMemory.cpp
+++ b/src/vsg/vk/DeviceMemory.cpp
@@ -42,12 +42,14 @@ DeviceMemoryList vsg::getActiveDeviceMemoryList(VkMemoryPropertyFlagBits propert
 //
 // DeviceMemory
 //
-DeviceMemory::DeviceMemory(Device* device, const VkMemoryRequirements& memRequirements, VkMemoryPropertyFlags properties, void* pNextAllocInfo) :
+DeviceMemory::DeviceMemory(RefCountBase* refCount, Device* device, const VkMemoryRequirements& memRequirements, VkMemoryPropertyFlags properties, void* pNextAllocInfo) :
     _memoryRequirements(memRequirements),
     _properties(properties),
     _device(device),
     _memorySlots(memRequirements.size)
 {
+    assignRefCount(refCount);
+
     uint32_t typeFilter = memRequirements.memoryTypeBits;
 
     // find the memory type to use

--- a/src/vsg/vk/Instance.cpp
+++ b/src/vsg/vk/Instance.cpp
@@ -122,9 +122,11 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsMessengerCallback(
     return VK_FALSE;
 }
 
-Instance::Instance(Names instanceExtensions, Names layers, uint32_t vulkanApiVersion, AllocationCallbacks* allocator) :
+Instance::Instance(RefCountBase* refCount, Names instanceExtensions, Names layers, uint32_t vulkanApiVersion, AllocationCallbacks* allocator) :
     apiVersion(vulkanApiVersion)
 {
+    assignRefCount(refCount);
+
     // application info
     VkApplicationInfo appInfo = {};
     appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;


### PR DESCRIPTION
This PR implements a new kind of `ref_ptr` that attempts to combine the best of both worlds from `std::shared_ptr` and classic intrusive reference-counted smart pointers like the existing implementation of `vsg::ref_ptr`.

`vsg::ref_ptr` has the advantages that:
* It's half the size of `std::shared_ptr` as it only needs to hold a pointer to the object itself, not a separate reference count. This is good for cache locality as each cache line can fit twice as many pointers.
* If you're given a plain C pointer to a reference-counted object, you can expect it to work properly if you store it in a `ref_ptr`, whereas `std::shared_ptr` would make a second control block unless you explicitly used `std::enable_shared_from_this`, which makes it intrusive after all.

`std::shared_ptr` has the advantages that:
* It's a standard C++ feature, so people already know how to use it, and someone else maintains it.
* It works with any normal type, even if it wasn't written with `shared_ptr` in mind.
* `std::weak_ptr` can be locked using only atomic operations instead of requiring a mutex. On typical desktop hardware, this is far, far faster, e.g. on x86, correctly-aligned operations on less than eight bytes are always atomic, so with relaxed ordering, atomic operations can be free.
  - We've seen at least one VSG-based app where most of the frametime was burned on locking `vsg::observer_ptr`s because they'd been ported from `std::weak_ptr`, and no one expected such a huge performance difference, so no one checked whether it was causing problems.
* It supports custom allocators per instance, and type-erases them so they can be passed to functions that expect a regular `shared_ptr` instead of a weird subclass.
  - When doing the intersector optimisation work, it didn't take long for waiting for allocations of runtime-sized temporaries to be the dominant factor. Swapping some from using the `vsg::Allocator` for the type being allocated to an appropriate `std::pmr::memory_resource` subclass gave significant improvements. I bodged that by making a `vsg::ref_ptr` subclass that would deallocate using the right memory resource, but that's not suitable for real-world usage as if any other `ref_ptr` to the objects had been the last one to be destroyed, it'd use the wrong deallocation function. With `std::shared_ptr` I could have just called `std::allocate_shared` with a `std::pmr::polymorphic_allocator` and everything would work properly.
  - In other situations, an application may know something about access patterns etc. that makes its own strategy better than relying on the VSG affinity system, e.g. knowing that some instances are only temporary, so avoiding fragmenting the memory used to hold instances used over multiple frames, or having multiple threads construct things in parallel that aren't going to be accessed at the same time but which have the same affinity, so would otherwise end up co-located. With the ability to set the allocator per instance rather than per type, these situations can be addressed.
* It supports custom deleters per instance, and type-erases them so they can be passed to functions that expect a regular `shared_ptr` instead of a weird subclass.
  - It might be a more idiomatic way to do the things that `vsg::Object::attemptDelete` does (although I've not seen that actually be used for anything in a VSG app and it's unused in the examples, so can't be sure).
  - This can be used, e.g. to return objects to a pool for reuse rather than actually destroying them.
  - Most of the use cases I can think of or have used STL smart pointer custom deleters for in the past aren't particularly relevant for the VSG, e.g. the go-to example is managing an object returned from a C API that needs a particular function called to destroy it without having to wrap it in a RAII class with a destructor.
* It supports fancy tricks like aliased pointers, so e.g. a function can take a `std::shared_ptr<int>` as a parameter and be passed a pointer to an `int` that's really a member of an instance of a class managed by a shared pointer, and keep the class instance alive.

The implementation in this PR:
* Keeps the `sizeof(vsg::ref_ptr<T>) == sizeof(T*)` property by not pointing to the control block in the pointer instance but instead doing it from the pointed-to instance. This doesn't make the pointed-to type bigger because there were already four bytes of padding after the reference count in `vsg::Object`, so holding a pointer instead of an atomic integer just fills in that padding.
* Keeps the adoption of existing instances working, as there's no new control block created when making a `ref_ptr` to something that's already reference counted.
* Resembles the STL smart pointers a little more closely, so should existing C++ programmers adopting the VSG should be surprised a bit less. Also, I used existing STL code as a reference point, so hopefully that means we'll benefit from the fact that it's been so widely used that all bugs should have been found and fixed.
* Makes `vsg::observer_ptr`s convertible to `vsg::ref_ptr` without locking a mutex, using atomic operations instead. This should be *much* faster in apps that use a lot of `observer_ptr`s (or allow apps that don't use them to start doing so).
* Supports custom allocators per instance.
  - In my testing, this is as fast as the dodgy PMR-specific subclass but without any of the fragility or huge potential for misuse.
  - When not using a custom allocator, the overhead *should* be zero over the existing implementation - there's a virtual function call that wasn't there before, but the existing virtual call to `attemptDelete` is gone (because I don't believe that feature is necessary any more).
* Supports custom deleters per instance.
  - This came basically for free once the support for custom allocators was implemented, as it's just calling `operator()` on a template argument.
  - This Should™ be a suitable alternative to the `attemptDelete` system, but again, there don't seem to be any public use cases for it, so I can't demonstrate how to port them. Obviously, we need to discuss this.
* Does not support aliased pointers - you obviously can't have an intrusive reference count in a type like `int`, so the main use case can't work.

There are some limitations and unanswered questions, some of which are potentially easily addressed and/or already existed:
* To adopt objects created with `new`, I had to make `ref_ptr` able to directly access the `_referenceCount` member, so the `ref`/`unref` methods of `vsg::Object` became apparently redundant, and I've commented them out for now. I'm not entirely sure adopting objects created with `new` is particularly important, though, as everything could just use `vsg::Whatever::create` or the new `vsg::make_referenced<Whatever>`. Forcing that would be a breaking change, so I didn't want to include it if I didn't have to, but it might be a good idea. It could also make it less error-prone to stack-allocate VSG classes, as a null reference count could be interpreted as meaning an instance isn't heap-allocated. That's something that could be checked at runtime, and if anything was misused, it'd be an easily-debugged immediate segfault rather than delayed memory corruption like the existing implementation would cause.
* There's some heavily templated code that makes things work. By modern C++ standards, it's not *that* bad (and I've gone out of my way to make it more readable than some of the STL code it was based on), but it's more complicated than it was before.
  - I left out some empty base class optimisation/compressed pair optimisations all STL implementations use as they make things much less readable. If the VSG used C++20, then they could be replaced by the `[[no_unique_address]]` attribute, which is much more readable. This shouldn't be a big deal for now, as it's only relevant when an empty type is used as a template parameter, e.g. passing in a plain function as a deleter or using a stateless allocator, and for now, the use case I'm addressing has a `std::pmr::polymorphic_allocator`, which isn't stateless.
  - I've tucked some of the templatey stuff away into a `vsg::detail` namespace so it doesn't pollute the main `vsg` namespace.
  - The code ended up triggering an intentionally-enabled warning with MSVC (but it does the thing the warning warns about on purpose because it's the right thing in this specific situation), and a buggy warning with GCC, so there are some `#pragma`s to suppress these, which makes some things look more complicated than they are.
  - Because many VSG classes have a non-public destructor so they can't be stack allocated:
    * lots of the C++ machinery around allocators doesn't work, so things that should be one-liners are more complicated
    * lots of the things to simplify that only arrived with C++20, so they're complicated two times over
    * there's some machinery to make sure the destructor can be called where it's needed.

    As I think the justification for the `vsg::Object` destructor being protected has been reduced with this PR, I'd be in favour of making it public, and then these could be tidied up.
* `std::enable_shared_from_this` doesn't work when called from an object's constructor (it must have been fully constructed and adopted by a `std::shared_ptr` first). On the other hand, `vsg::Object` subclasses can and do pass `this` to `ref_ptr`/`observer_ptr` in their constructors. There's no entirely automatic way to preserve this ability (or at least not one that's reliable - there are lots of possible hacks that would only work sometimes).

  The most sensible compromise was to make a custom type trait that controls whether the reference count is passed to the constructor, as that way, only a handful of classes needed to be changed and the rest would keep working exactly as they always have. I've gone through and adjusted all the affected classes I can find in the public VSG projects, which all turned out to be in the main VSG repo, so this shouldn't cause problems. Affected applications can copy the change from `DeviceMemory` etc. as it's not complicated.

  The two biggest potential issues are:
  - it's not obvious what will be affected at a glance as a basic search for `this` obviously gives lots of places it's not used in a constructor. I `grep`ped with PCRE subroutines to search for the `this` keyword only within constructors, so believe I've got everything, but I'm pretty sure some people's brains would melt if they tried to read the regular expressions I wrote. If a search like that isn't done, then problems will only present themselves at runtime, which isn't ideal.
  - In the `vsg::Object` copy constructor, there was a branch where `this` is used and assigned to a `ref_ptr`. As that's the base class for everything, if I kept that, we'd need to take the ref count in the copy constructors for everything, which would be a huge pain. After investigating the branch, though, it looks like it's only reachable if a `CopyOp` is going to assign the same object to the same pointer once its constructor has finished anyway, so I don't think it's accomplishing anything productive. I've therefore commented it out for now, but it was originally added after the `CopyOp` stuff that I think makes it redundant. It would definitely be good to have a second pair of eyes on this.
* `vsg::Auxiliary` is managed with a plain C pointer and explicit reference adjustment in `vsg::Object`, which I think is a bit odd as it looks like a `vsg::ref_ptr` would be fine. If that's right, then some things could be simplified a little by making that change.
* As there's now a `std::shared_ptr`-style control block rather than just an atomic uint in each object, that obviously needs to live somewhere. The obvious solution is to allocate it as its own object, but that means an extra allocator call, and it was the allocator taking too long that motivated me to start this. `std::make_shared` and `std::allocate_shared` use an alternative approach - they define a templated struct that includes both the reference count and the managed object, which means a single allocator call can deal with both.
  *Technically* that's not required by the standard, but it does recommend it and all extant implementations do so, so the organisations maintaining STL implementations seem to have decided that it's faster in the general case.

  The VSG isn't necessarily the general case, though. Putting the control block in the same allocation as the managed object would, on the face of it, be beneficial if the reference count is typically accessed when the object is (e.g. it's usually assigned to a fresh `ref_ptr` when it's accessed) as they'll land in the same cache line, or when allocation itself is the most expensive operation to happen to objects, and be counterproductive if other objects are typically accessed at the same time as other objects without accessing the ref count (e.g. the record traversal) as the ref count being in the same cache line means something else isn't.

  The `vsggroups` example exists and on paper, would be an excellent tool for testing this kind of change.
  However, [as my post the other day](https://github.com/vsg-dev/VulkanSceneGraph/discussions/1698) explains, its results are very sensitive to things that they ideally wouldn't be. Initially, testing on Windows with MSVC in the RelWithDebInfo configuration, I was seeing no performance degradation during traversal from collocating the control block, which was a pleasant surprise, but when I came to do final thorough testing, I noticed some odd results, e.g.:
  * MSVC RelWithDebInfo was actually consistently faster with this PR...
  * but MSVC Release was consistently slower (even though the sequence of instructions executed and memory locations accessed was identical to RelWithDebInfo).
  * GCC on Windows and Linux showed about the impact I'd expected, so I tried with separately-allocated control blocks...
  * which left GCC still showing a performance change (although now sometimes an improvement) despite the instructions executed and memory addresses accessed during traversal being the same with and without the PR...
  * and the gap between different MSVC builds shrinking, but not disappearing.

  This prompted my investigation into the `vsggroups` example, and it turned out that I could induce impacts much bigger than this PR produces by doing things that shouldn't make any difference to anything, e.g. adding some functions to various source files and only calling them after the traversal benchmark has finished.

  As far as I can tell, the factor causing the differences is really just whether the compiler/linker happen to put functions called during traversal into adjacent memory addresses that end up mapping to the same instruction cache line. This is really easy to influence in a small benchmark app like `vsggroups` (usually making things worse). However, in a real application with many more functions, it's much less likely to get lucky enough to have a meaningful number of functions that are called consecutively and small enough to share a cache line actually end up in the same cache line, and especially not also end up the only functions executed on a hot path.

  Depending on the machine I test on, after I've attempted to exclude the effect from binary layout, the impact on pure traversal time of collocating the control block seems to be around 3% on a machine with fast RAM and 5% on a machine with slower RAM, but these are fairly rough figures because the binary layout effects can be double digit percentages, so it's hard to isolate what's what and whether one result is more or less directly comparable to the baseline than another is.

  I've therefore opted not to collocate the control block by default so the cache pressure from nodes themselves is unchanged by this PR, and for simplicity, it's allocated with a regular `new` call. That will have a (likely small) performance impact in some specific cases, e.g. allocating a lot of VSG objects (but it's already been decided that it's okay for doing that to not be super fast, hence it being fine that the VSG allocator is significantly slower than plain `malloc`), or when a lot of things are `ref`ed/`unref`ed in quick succession. Sometimes, the impact will be positive, though, e.g. if a lot of objects are `unref`ed on different threads, as even on architectures like x86 where small memory accesses are always atomic, they're relaxed atomics rather than strict, so writes still need to stall the thread if any other core has the target address cached. Reducing the chances that atomics accessed without `std::memory_order_relaxed` end up in the same cache line can therefore be helpful.

  If we knew that decrementing reference counts could afford to be slow, or could predict which objects were likely to be `unref`ed from one thread while another thread was using them, there'd be easy gains here by allocating the reference count with `std::pmr::synchronised_pool_resource`, so that might be worth pursuing. It might not make any difference one way or the other to real apps, though, so there's no point until we've confirmed it matters with a profiler.
* There might be places in the VSG where using the new abilities this provides ends up giving a performance improvement, e.g. anywhere temporary `vsg::Object` subclass instances are made and then discarded before the next frame. I've only investigated using it with `vsg::Intersector` and it won't give a statistically significant improvement there without the other changes.

Obviously, this is a fairly invasive change as it affects some of the core classes that everything uses, so it needs more careful consideration than a typical PR.

### Possible alternatives

Before doing all this, I experimented with an alternative where `vsg::Auxiliary` held a `std::optional<std::function>`, which could optionally be used as a deleter instead of the `delete` operator.
That was much less invasive, but:
* There are comments that imply a `vsg::Auxiliary` instance isn't necessarily unique to a particular `vsg::Object` instance, and that opens a can of worms with using the wrong deleter with the wrong memory. Potentially, this could be shored up a bit, though.
* Performing a second allocation for the `vsg::Auxiliary` becomes mandatory, and that undid the performance improvement from using a specialised allocator in the first place. Potentially, something could be implemented to allow constructing a `vsg::Auxiliary` in the same allocation as its `vsg::Object`, though.
* `vsg::Auxiliary` has a `std::map` member, and the C++ specification permits `std::map` to require a node to be allocated even for an empty map to represent the end node. libc++ and libstdc++ put the end node within the `std::map` instance, but the Microsoft STL allocates it on the heap, and Windows with MSVC is a target platform of the client app I was originally trying to optimise, so this third allocation ends up making everything slower than it started. Potentially, this could be mitigated by making `vsg::Auxiliary::userObjects` a `std::optional<ObjectMap>` instead of an `ObjectMap`, though, and only initialise it if it's used.
* As this is a feature intended for things that are particularly performance-sensitive, it's a bit backwards to force them to opt into extra operations and an associated performance penalty.
* It doesn't address the secondary goal of making `vsg::observer_ptr` stop being surprisingly much slower than `std::weak_ptr`, which we know has caught people out in the past.

It's worth having a brief mention of the idea of using `std::shared_ptr` instead of `vsg::ref_ptr`, but:
* We know it's slower, even if we avoid using `std::make_shared`/`std::allocate_shared` to mitigate the putting-48-bytes-of-control-block-between-every-pair-of-nodes problem that undermines the `vsg::IntrusiveAllocator` gains.
* Now the VSG does things that involve passing `this` pointers to things during constructors, those are going to be a pain to unpick.

We therefore wouldn't want to switch to `std::shared_ptr` without a compelling reason, and this PR reduces the number of reasons.

### Next steps

I'd hoped to make a quick proof-of-concept for this and have a discussion about it at an earlier stage, but between solving edge cases that needed to work before most of the examples would run and then investigating why the performance numbers were weird, getting it to a stage where it was worth discussing has taken longer than I'd have liked.

In terms of testing this, on paper, it should be reliable, but I've only got limited access to real VSG apps, so don't want to make a blanket statement that everything will just work. The impact on framerates should be zero for apps that don't do a lot of allocations and deallocations within a frame, and if they do that, there should be new optimisations possible using the new features here that will allow better performance than before. Operations like initial loading that do a lot of allocations are expected to be a little slower, but hopefully not too much. If it's a problem, then we can look at changing how control blocks are allocated. Any traversal performance changes reported by `vsggroups` are more likely to be caused by its unreliability than this PR.

There's obviously some tidying to do once some of the points to discuss have been resolved, too.