### PR TITLE
Fix Device::availableMemory crash on Vulkan 1.0 instances

### DIFF
--- a/include/vsg/vk/Device.h
+++ b/include/vsg/vk/Device.h
@@ -85,6 +85,9 @@ namespace vsg
         /// return true if Device was created with specified extension
         bool supportsDeviceExtension(const char* extensionName) const;
 
+        /// commonly checked extensions cached at construction
+        const bool memory_budget = false; // VK_EXT_memory_budget usable on this Device
+
         /// return the amount of remaining memory, compatible with specified flags, available that can be allocated.
         VkDeviceSize availableMemory(VkMemoryPropertyFlags memoryPropertiesFlags, double allocatedMemoryLimit = 1.0) const;
 

--- a/src/vsg/vk/Device.cpp
+++ b/src/vsg/vk/Device.cpp
@@ -163,6 +163,11 @@ Device::Device(PhysicalDevice* physicalDevice, const QueueSettings& queueSetting
     }
 
     _extensions = DeviceExtensions::create(this);
+
+    // Cache extension/version probes used on hot paths. VK_EXT_memory_budget piggy-backs on
+    // vkGetPhysicalDeviceMemoryProperties2 which requires Vulkan 1.1 (or the KHR variant).
+    const_cast<bool&>(memory_budget) = supportsApiVersion(VK_API_VERSION_1_1) &&
+                                       supportsDeviceExtension(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME);
 }
 
 Device::~Device()
@@ -208,17 +213,24 @@ bool Device::supportsDeviceExtension(const char* extensionName) const
 
 VkDeviceSize Device::availableMemory(VkMemoryPropertyFlags memoryPropertiesFlags, double allocatedMemoryLimit) const
 {
-    VkPhysicalDeviceMemoryBudgetPropertiesEXT memoryBudget;
-    memoryBudget.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT;
-    memoryBudget.pNext = nullptr;
+    VkPhysicalDeviceMemoryProperties memoryProperties;
+    VkPhysicalDeviceMemoryBudgetPropertiesEXT memoryBudget = {};
 
-    VkPhysicalDeviceMemoryProperties2 dmp;
-    dmp.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
-    dmp.pNext = &memoryBudget;
+    if (memory_budget)
+    {
+        memoryBudget.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT;
 
-    vkGetPhysicalDeviceMemoryProperties2(*(getPhysicalDevice()), &dmp);
+        VkPhysicalDeviceMemoryProperties2 dmp = {};
+        dmp.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
+        dmp.pNext = &memoryBudget;
 
-    auto& memoryProperties = dmp.memoryProperties;
+        vkGetPhysicalDeviceMemoryProperties2(*(getPhysicalDevice()), &dmp);
+        memoryProperties = dmp.memoryProperties;
+    }
+    else
+    {
+        vkGetPhysicalDeviceMemoryProperties(*(getPhysicalDevice()), &memoryProperties);
+    }
 
     VkDeviceSize availableSpace = 0;
     for (uint32_t i = 0; i < memoryProperties.memoryTypeCount; ++i)
@@ -227,8 +239,10 @@ VkDeviceSize Device::availableMemory(VkMemoryPropertyFlags memoryPropertiesFlags
         {
             uint32_t heapIndex = memoryProperties.memoryTypes[i].heapIndex;
 
-            VkDeviceSize heapBudget = static_cast<VkDeviceSize>(static_cast<double>(memoryBudget.heapBudget[heapIndex]) * allocatedMemoryLimit);
-            VkDeviceSize heapUsage = memoryBudget.heapUsage[heapIndex];
+            VkDeviceSize heapBudget = memory_budget ? memoryBudget.heapBudget[heapIndex] : memoryProperties.memoryHeaps[heapIndex].size;
+            VkDeviceSize heapUsage = memory_budget ? memoryBudget.heapUsage[heapIndex] : 0;
+
+            heapBudget = static_cast<VkDeviceSize>(static_cast<double>(heapBudget) * allocatedMemoryLimit);
             VkDeviceSize heapAvailable = (heapUsage < heapBudget) ? heapBudget - heapUsage : 0;
             availableSpace += heapAvailable;
 


### PR DESCRIPTION
## Description

`Device::availableMemory()` unconditionally calls `vkGetPhysicalDeviceMemoryProperties2` with a chained `VkPhysicalDeviceMemoryBudgetPropertiesEXT`. Both have preconditions that are never checked:

- `vkGetPhysicalDeviceMemoryProperties2` requires Vulkan 1.1 (or `VK_KHR_get_physical_device_properties2`, promoted to core in 1.1).
- `VkPhysicalDeviceMemoryBudgetPropertiesEXT` requires the `VK_EXT_memory_budget` device extension.

When a VSG application creates a `vsg::Instance` with `VK_API_VERSION_1_0` (still the default of `vsg::Instance::create`), this function dispatches an unresolved entry point and feeds the driver a struct it never advertised support for. Behaviour is undefined. On Mesa Lavapipe it segfaults inside a driver worker thread during normal scene compilation (`MemoryBufferPools::reserveBuffer` -> `Device::availableMemory`). The Khronos validation layer flags it as:

> `vkGetPhysicalDeviceMemoryProperties2()`: Attempted to call with an effective API version of 1.0.0 … but this API was not promoted until version 1.1.0.

## Fix

Gate the 1.1 path on both `supportsApiVersion(VK_API_VERSION_1_1)` and `supportsDeviceExtension(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME)`. When either is missing, fall back to the Vulkan 1.0 `vkGetPhysicalDeviceMemoryProperties` and treat `memoryHeaps[i].size` as the budget with zero live usage. The fallback returns a conservative upper bound — buffer pool sizing degrades gracefully instead of crashing.

No public API changes. The 1.1 + extension code path is unchanged for users who request it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Reproduced and verified on Mesa 25.2.8 Lavapipe (`lvp_icd.json`) in a GPU-less Linux container with a minimal headless VSG application (`vsg::Instance::create(..., VK_API_VERSION_1_0)`, offscreen framebuffer, one `Builder::createSphere` frame).

- Before the patch: SIGSEGV inside `libvulkan_lvp.so` during `viewer->compile()`, validation layer reports the API-version violation above.
- After the patch: clean run, no validation errors, expected image written.

**Test Configuration**:
- OS: Ubuntu 24.04 (LXC container, no GPU)
- Vulkan loader: 1.3.275
- Driver: Mesa 25.2.8 Lavapipe (LLVM 20.1.2)
- Compiler: GCC 13.3.0

## Checklist

- [x] My code follows the style guidelines of this project (clang-format clean)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings